### PR TITLE
Fix database and Gmail compatibility

### DIFF
--- a/app/db/db_management.py
+++ b/app/db/db_management.py
@@ -6,6 +6,8 @@ import os
 import sys
 from datetime import datetime, timedelta
 
+from sqlalchemy import text
+
 try:
     from database import Base, db_manager, engine
 
@@ -86,7 +88,7 @@ def test_connection():
     try:
         # Try to execute a simple query
         with engine.connect() as conn:
-            result = conn.execute("SELECT 1")
+            result = conn.execute(text("SELECT 1"))
             result.fetchone()
 
         print("Database connection successful!")

--- a/app/utils/email_util.py
+++ b/app/utils/email_util.py
@@ -11,6 +11,9 @@ def send_email(subject, body, to_emails, from_email, app_password, html_body=Non
     if not to_emails or not from_email or not app_password:
         logger.warning("Gmail credentials not set, skipping email notification.")
         return
+    # Google displays 16-character app passwords in four groups for readability.
+    # SMTP authentication expects the password without spaces or line breaks.
+    app_password = "".join(app_password.split())
     # Use multipart/alternative so email clients render either HTML (preferred) OR plain text (fallback),
     # instead of showing both versions back-to-back.
     msg = MIMEMultipart("alternative")

--- a/log.txt
+++ b/log.txt
@@ -8712,3 +8712,7 @@ Finish job at time 2026-02-16 22:21:51.109070
 2026-03-03 20:51:27.808777 | Binance | AAVE | Action: NO ACTION | Buy %: 0.9 | Sell %: 0.9
 Finish job at time 2026-03-03 20:52:05.281603
 
+2026-08-03 09:29:29.376015 | Binance | DOGE | Action: NO ACTION | Buy %: 0.1 | Sell %: 0.1
+2026-08-03 09:30:43.352528 | Binance | AAVE | Action: NO ACTION | Buy %: 0.9 | Sell %: 0.1
+Finish job at time 2026-08-03 09:30:48.629451
+


### PR DESCRIPTION
## Summary
- use SQLAlchemy text() for database connection checks
- normalize whitespace in Gmail app passwords before SMTP login
- include the latest trading run log entries

## Validation
- database connection test passed
- Gmail SMTP authentication and test delivery passed
- full pytest: 158 passed, 3 skipped, 37 failed, 2 errors (existing strategy configuration expectations and missing API fixtures)