### PR TITLE
add backtesting benchmark

### DIFF
--- a/app/backtesting/__init__.py
+++ b/app/backtesting/__init__.py
@@ -1,0 +1,1 @@
+"""Backtesting utilities."""

--- a/app/backtesting/benchmark_validation.py
+++ b/app/backtesting/benchmark_validation.py
@@ -1,0 +1,396 @@
+"""Cross-asset validation for simple daily strategies with realistic execution."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+from statistics import mean, median
+from typing import Any, Sequence
+
+import numpy as np
+
+from app.backtesting.walk_forward import (
+    Candidate,
+    _driver_kwargs,
+    build_walk_forward_folds,
+    compound_returns,
+    load_daily_data,
+)
+from app.trading.trader_driver import TraderDriver
+from app.core.config import CURS
+
+
+EXECUTION_FRICTION_RATE = 0.02
+INITIAL_CAPITAL = 10_000.0
+TARGET_STRATEGY_NAMES = (
+    "cash",
+    "buy_hold",
+    "sma200_trend",
+    "dual_ma_50_200",
+    "volatility_target",
+    "regime_switch",
+)
+STRATEGY_NAMES = (*TARGET_STRATEGY_NAMES, "ma_boll_fixed")
+
+
+def _rolling_mean(values: np.ndarray, window: int) -> np.ndarray:
+    result = np.full(len(values), np.nan)
+    if len(values) >= window:
+        result[window - 1 :] = np.convolve(
+            values, np.ones(window) / window, mode="valid"
+        )
+    return result
+
+
+def _rolling_std(values: np.ndarray, window: int) -> np.ndarray:
+    result = np.full(len(values), np.nan)
+    for index in range(window - 1, len(values)):
+        result[index] = float(np.std(values[index - window + 1 : index + 1]))
+    return result
+
+
+def build_strategy_targets(data: Sequence[Sequence[Any]]) -> dict[str, Any]:
+    """Create close-derived targets; every target is executed at the next open."""
+    closes = np.asarray([float(row[0]) for row in data], dtype=float)
+    sma20 = _rolling_mean(closes, 20)
+    sma50 = _rolling_mean(closes, 50)
+    sma200 = _rolling_mean(closes, 200)
+    returns = np.zeros(len(closes))
+    returns[1:] = np.diff(closes) / closes[:-1]
+    vol20 = _rolling_std(returns, 20)
+    price_std20 = _rolling_std(closes, 20)
+
+    cash = np.zeros(len(closes))
+    buy_hold = np.ones(len(closes))
+    sma_trend = np.where(np.isnan(sma200), 0.0, (closes > sma200).astype(float))
+    dual_ma = np.where(
+        np.isnan(sma200) | np.isnan(sma50), 0.0, (sma50 > sma200).astype(float)
+    )
+    daily_target_vol = 0.50 / np.sqrt(365.0)
+    vol_target = np.where(
+        np.isnan(vol20) | (vol20 <= 0),
+        0.0,
+        np.clip(daily_target_vol / vol20, 0.0, 1.0),
+    )
+
+    regime_target = np.zeros(len(closes))
+    regimes = np.full(len(closes), "WARMUP", dtype=object)
+    previous_target = 0.0
+    for index in range(len(closes)):
+        if index < 219 or np.isnan(sma200[index]):
+            continue
+        slope = sma200[index] / sma200[index - 20] - 1.0
+        if closes[index] > sma200[index] and slope > 0:
+            regimes[index] = "BULL"
+            previous_target = 1.0
+        elif closes[index] < sma200[index] and slope < 0:
+            regimes[index] = "BEAR"
+            previous_target = 0.0
+        else:
+            regimes[index] = "RANGE"
+            lower = sma20[index] - 2.0 * price_std20[index]
+            upper = sma20[index] + 2.0 * price_std20[index]
+            if closes[index] < lower:
+                previous_target = 1.0
+            elif closes[index] > upper:
+                previous_target = 0.0
+        regime_target[index] = previous_target
+
+    return {
+        "targets": {
+            "cash": cash,
+            "buy_hold": buy_hold,
+            "sma200_trend": sma_trend,
+            "dual_ma_50_200": dual_ma,
+            "volatility_target": vol_target,
+            "regime_switch": regime_target,
+        },
+        "regimes": regimes,
+    }
+
+
+def simulate_target_strategy(
+    data: Sequence[Sequence[Any]],
+    targets: Sequence[float],
+    test_start: int,
+    test_end: int,
+    slippage_bps: float = 10.0,
+    rebalance_threshold: float = 0.10,
+) -> dict[str, float | int]:
+    """Trade previous-close targets at the next open with 2% friction and slippage."""
+    if slippage_bps < 0:
+        raise ValueError("slippage_bps cannot be negative")
+    cash = INITIAL_CAPITAL
+    coin = 0.0
+    trades = 0
+    turnover = 0.0
+    equity_curve = []
+    exposures = []
+    slip = slippage_bps / 10_000.0
+
+    for index in range(test_start, test_end):
+        close_price = float(data[index][0])
+        open_price = float(data[index][2])
+        desired = float(np.clip(targets[index - 1], 0.0, 1.0))
+        open_equity = cash + coin * open_price
+        current = 0.0 if open_equity <= 0 else coin * open_price / open_equity
+
+        if abs(desired - current) >= rebalance_threshold:
+            if desired > current:
+                spend = min(cash, (desired - current) * open_equity)
+                if spend > 0:
+                    execution_price = open_price * (1.0 + slip)
+                    coin += spend * (1.0 - EXECUTION_FRICTION_RATE) / execution_price
+                    cash -= spend
+                    turnover += spend / open_equity
+                    trades += 1
+            else:
+                sell_value = min(coin * open_price, (current - desired) * open_equity)
+                if sell_value > 0:
+                    execution_price = open_price * (1.0 - slip)
+                    sell_coin = min(coin, sell_value / open_price)
+                    coin -= sell_coin
+                    cash += (
+                        sell_coin * execution_price * (1.0 - EXECUTION_FRICTION_RATE)
+                    )
+                    turnover += sell_value / open_equity
+                    trades += 1
+
+        equity = cash + coin * close_price
+        equity_curve.append(equity)
+        exposures.append(0.0 if equity <= 0 else coin * close_price / equity)
+
+    peaks = np.maximum.accumulate(np.asarray(equity_curve))
+    drawdowns = (peaks - np.asarray(equity_curve)) / peaks
+    return {
+        "return": (equity_curve[-1] / INITIAL_CAPITAL - 1.0) * 100.0,
+        "max_drawdown": float(np.max(drawdowns)) * 100.0,
+        "transactions": trades,
+        "turnover": turnover,
+        "mean_exposure": mean(exposures),
+    }
+
+
+def simulate_fixed_ma_boll(
+    data: Sequence[Sequence[Any]],
+    test_start: int,
+    test_end: int,
+    slippage_bps: float = 10.0,
+    warmup_days: int = 35,
+) -> dict[str, float | int | None]:
+    """Run one shared MA-BOLL configuration without per-asset tuning."""
+    candidate = Candidate(
+        strategy="MA-BOLL-BANDS",
+        tol_pct=0.1,
+        buy_pct=0.5,
+        sell_pct=0.5,
+        bollinger_sigma=2.0,
+    )
+    warmup_start = max(0, test_start - warmup_days)
+    combined = list(data[warmup_start:test_end])
+    warmup_points = test_start - warmup_start
+    driver = TraderDriver(**_driver_kwargs("MA_BOLL_FIXED", candidate, slippage_bps))
+    driver.feed_data(combined, warmup_points=warmup_points)
+    trader = driver.traders[0]
+    return {
+        "return": float(trader.rate_of_return),
+        "max_drawdown": float(trader.max_drawdown) * 100.0,
+        "transactions": int(trader.num_transaction),
+        "turnover": None,
+        "mean_exposure": None,
+    }
+
+
+def validate_symbol(
+    symbol: str,
+    data: Sequence[Sequence[Any]],
+    train_days: int = 365,
+    validation_days: int = 90,
+    test_days: int = 30,
+    purge_days: int = 7,
+    slippage_bps: float = 10.0,
+) -> dict[str, Any]:
+    features = build_strategy_targets(data)
+    folds = build_walk_forward_folds(
+        len(data), train_days, validation_days, test_days, purge_days
+    )
+    fold_results = []
+    for fold in folds:
+        strategies = {
+            name: simulate_target_strategy(
+                data,
+                features["targets"][name],
+                fold.test_start,
+                fold.test_end,
+                slippage_bps,
+            )
+            for name in TARGET_STRATEGY_NAMES
+        }
+        strategies["ma_boll_fixed"] = simulate_fixed_ma_boll(
+            data,
+            fold.test_start,
+            fold.test_end,
+            slippage_bps,
+        )
+        market_return = (
+            float(data[fold.test_end - 1][0]) / float(data[fold.test_start][0]) - 1.0
+        ) * 100.0
+        benchmark_return = strategies["buy_hold"]["return"]
+        for metrics in strategies.values():
+            metrics["excess_vs_buy_hold"] = metrics["return"] - benchmark_return
+        signal_regimes = features["regimes"][fold.test_start - 1 : fold.test_end - 1]
+        fold_results.append(
+            {
+                "fold": fold.fold,
+                "test_start": data[fold.test_start][1],
+                "test_end": data[fold.test_end - 1][1],
+                "market_return": market_return,
+                "regime_counts": dict(Counter(signal_regimes)),
+                "strategies": strategies,
+            }
+        )
+
+    oos_start = folds[0].test_start
+    oos_end = folds[-1].test_end
+    continuous_results = {
+        name: simulate_target_strategy(
+            data,
+            features["targets"][name],
+            oos_start,
+            oos_end,
+            slippage_bps,
+        )
+        for name in TARGET_STRATEGY_NAMES
+    }
+    continuous_results["ma_boll_fixed"] = simulate_fixed_ma_boll(
+        data,
+        oos_start,
+        oos_end,
+        slippage_bps,
+    )
+    continuous_benchmark = continuous_results["buy_hold"]["return"]
+
+    summaries = {}
+    for name in STRATEGY_NAMES:
+        returns = [fold["strategies"][name]["return"] for fold in fold_results]
+        excess = [
+            fold["strategies"][name]["excess_vs_buy_hold"] for fold in fold_results
+        ]
+        summaries[name] = {
+            "continuous_oos_return": continuous_results[name]["return"],
+            "continuous_excess_vs_buy_hold": (
+                continuous_results[name]["return"] - continuous_benchmark
+            ),
+            "fold_compounded_return": compound_returns(returns),
+            "mean_fold_return": mean(returns),
+            "median_fold_return": median(returns),
+            "mean_excess_vs_buy_hold": mean(excess),
+            "excess_win_rate": sum(value > 0 for value in excess) / len(excess),
+            "continuous_transactions": continuous_results[name]["transactions"],
+            "continuous_turnover": continuous_results[name]["turnover"],
+            "continuous_max_drawdown": continuous_results[name]["max_drawdown"],
+            "mean_fold_max_drawdown": mean(
+                fold["strategies"][name]["max_drawdown"] for fold in fold_results
+            ),
+        }
+
+    return {
+        "symbol": symbol,
+        "data_start": data[0][1],
+        "data_end": data[-1][1],
+        "data_rows": len(data),
+        "folds": fold_results,
+        "summary": summaries,
+    }
+
+
+def aggregate_assets(results: Sequence[dict[str, Any]]) -> dict[str, Any]:
+    aggregate = {}
+    for name in STRATEGY_NAMES:
+        returns = [
+            result["summary"][name]["continuous_oos_return"] for result in results
+        ]
+        excess = [
+            result["summary"][name]["continuous_excess_vs_buy_hold"]
+            for result in results
+        ]
+        aggregate[name] = {
+            "median_asset_return": median(returns),
+            "median_asset_excess_vs_buy_hold": median(excess),
+            "positive_return_assets": sum(value > 0 for value in returns),
+            "positive_excess_assets": sum(value > 0 for value in excess),
+            "asset_count": len(results),
+        }
+    return aggregate
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Cross-asset daily strategy validation"
+    )
+    parser.add_argument("--symbols", nargs="+", default=CURS)
+    parser.add_argument("--train-days", type=int, default=365)
+    parser.add_argument("--validation-days", type=int, default=90)
+    parser.add_argument("--test-days", type=int, default=30)
+    parser.add_argument("--purge-days", type=int, default=7)
+    parser.add_argument("--slippage-bps", type=float, default=10.0)
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+
+    results = []
+    for symbol in args.symbols:
+        data = load_daily_data(symbol)
+        result = validate_symbol(
+            symbol.upper(),
+            data,
+            args.train_days,
+            args.validation_days,
+            args.test_days,
+            args.purge_days,
+            args.slippage_bps,
+        )
+        results.append(result)
+        regime = result["summary"]["regime_switch"]
+        print(
+            f"{symbol.upper()}: regime={regime['continuous_oos_return']:.2f}%, "
+            f"excess={regime['continuous_excess_vs_buy_hold']:.2f}%"
+        )
+
+    report = {
+        "configuration": {
+            "execution_friction_rate": EXECUTION_FRICTION_RATE,
+            "slippage_bps": args.slippage_bps,
+            "signal_time": "daily_close",
+            "execution_time": "next_daily_open",
+            "options_enabled": False,
+            "leverage_enabled": False,
+            "parameters_shared_across_assets": True,
+            "regime_parameters": {
+                "trend_ma_days": 200,
+                "trend_slope_days": 20,
+                "range_bollinger_days": 20,
+                "range_bollinger_sigma": 2.0,
+            },
+            "fixed_ma_boll_parameters": {
+                "tol_pct": 0.1,
+                "buy_pct": 0.5,
+                "sell_pct": 0.5,
+                "bollinger_sigma": 2.0,
+            },
+        },
+        "assets": results,
+        "cross_asset_summary": aggregate_assets(results),
+    }
+    output = args.output or Path("artifacts/backtests") / (
+        f"cross_asset_benchmarks_{datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%SZ')}.json"
+    )
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(report, indent=2), encoding="utf-8")
+    print(f"Saved report: {output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/app/backtesting/walk_forward.py
+++ b/app/backtesting/walk_forward.py
@@ -1,0 +1,420 @@
+"""Strict walk-forward backtesting using daily candles stored in PostgreSQL."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable, Sequence
+
+from sqlalchemy import select
+
+from app.core.config import (
+    BOLLINGER_MAS,
+    BOLLINGER_TOLS,
+    BUY_PCTS,
+    BUY_STAS,
+    CRYPTO_STRATEGIES,
+    CURS,
+    EMA_LENGTHS,
+    KDJ_OVERBOUGHT_THRESHOLDS,
+    KDJ_OVERSOLD_THRESHOLDS,
+    MA_LENGTHS,
+    RSI_OVERBOUGHT_THRESHOLDS,
+    RSI_OVERSOLD_THRESHOLDS,
+    RSI_PERIODS,
+    SELL_PCTS,
+    SELL_STAS,
+    TOL_PCTS,
+)
+from app.db.database import HistoricalData, SessionLocal
+from app.trading.trader_driver import TraderDriver
+
+
+@dataclass(frozen=True)
+class WalkForwardFold:
+    """Half-open row-index boundaries for a strict walk-forward fold."""
+
+    fold: int
+    train_start: int
+    train_end: int
+    validation_start: int
+    validation_end: int
+    purge_start: int
+    purge_end: int
+    test_start: int
+    test_end: int
+
+
+@dataclass(frozen=True)
+class Candidate:
+    strategy: str
+    tol_pct: float
+    buy_pct: float
+    sell_pct: float
+    bollinger_sigma: float
+    rsi_period: int | None = None
+    rsi_oversold: float | None = None
+    rsi_overbought: float | None = None
+    kdj_oversold: float | None = None
+    kdj_overbought: float | None = None
+
+
+def build_walk_forward_folds(
+    data_length: int,
+    train_days: int = 365,
+    validation_days: int = 90,
+    test_days: int = 30,
+    purge_days: int = 7,
+    step_days: int | None = None,
+) -> list[WalkForwardFold]:
+    """Build rolling folds with non-overlapping tests and a validation/test purge gap."""
+    if min(data_length, train_days, validation_days, test_days) <= 0:
+        raise ValueError("data_length and window sizes must be positive")
+    if purge_days < 0:
+        raise ValueError("purge_days cannot be negative")
+
+    step = test_days if step_days is None else step_days
+    if step < test_days:
+        raise ValueError(
+            "step_days must be >= test_days so test windows do not overlap"
+        )
+
+    required = train_days + validation_days + purge_days + test_days
+    folds = []
+    offset = 0
+    while offset + required <= data_length:
+        train_end = offset + train_days
+        validation_end = train_end + validation_days
+        purge_end = validation_end + purge_days
+        folds.append(
+            WalkForwardFold(
+                fold=len(folds) + 1,
+                train_start=offset,
+                train_end=train_end,
+                validation_start=train_end,
+                validation_end=validation_end,
+                purge_start=validation_end,
+                purge_end=purge_end,
+                test_start=purge_end,
+                test_end=purge_end + test_days,
+            )
+        )
+        offset += step
+    return folds
+
+
+def compound_returns(returns_pct: Iterable[float]) -> float:
+    """Compound percentage returns and return the result as a percentage."""
+    growth = math.prod(1.0 + value / 100.0 for value in returns_pct)
+    return (growth - 1.0) * 100.0
+
+
+def load_daily_data(symbol: str) -> list[list[Any]]:
+    """Load every stored daily candle for a symbol in chronological order."""
+    cache_key = symbol.upper()
+    if not cache_key.endswith("USDT"):
+        cache_key = f"{cache_key}USDT"
+    cache_key = f"{cache_key}__1d"
+
+    with SessionLocal() as session:
+        records = session.scalars(
+            select(HistoricalData)
+            .where(HistoricalData.symbol == cache_key)
+            .order_by(HistoricalData.date.asc())
+        ).all()
+
+    return [
+        [
+            row.close_price,
+            row.date.strftime("%Y-%m-%d %H:%M:%S"),
+            row.open_price,
+            row.low_price,
+            row.high_price,
+            row.volume,
+        ]
+        for row in records
+    ]
+
+
+def _candidate_from_trader(trader: Any) -> Candidate:
+    return Candidate(
+        strategy=trader.high_strategy,
+        tol_pct=float(trader.tol_pct),
+        buy_pct=float(trader.buy_pct),
+        sell_pct=float(trader.sell_pct),
+        bollinger_sigma=float(trader.bollinger_sigma),
+        rsi_period=getattr(trader, "rsi_period", None),
+        rsi_oversold=getattr(trader, "rsi_oversold", None),
+        rsi_overbought=getattr(trader, "rsi_overbought", None),
+        kdj_oversold=getattr(trader, "kdj_oversold", None),
+        kdj_overbought=getattr(trader, "kdj_overbought", None),
+    )
+
+
+def _metrics(trader: Any, data: Sequence[Sequence[Any]]) -> dict[str, float | int]:
+    strategy_return = float(trader.rate_of_return)
+    first_close = float(data[0][0])
+    last_close = float(data[-1][0])
+    buy_hold_return = (last_close / first_close - 1.0) * 100.0
+    return {
+        "strategy_return": strategy_return,
+        "buy_hold_return": buy_hold_return,
+        "excess_return": strategy_return - buy_hold_return,
+        "max_drawdown": float(trader.max_drawdown) * 100.0,
+        "transactions": int(trader.num_transaction),
+    }
+
+
+def _driver_kwargs(
+    name: str, candidate: Candidate | None = None, slippage_bps: float = 10.0
+) -> dict[str, Any]:
+    return {
+        "name": name,
+        "init_amount": 10_000,
+        "cur_coin": 0.0,
+        "overall_stats": [candidate.strategy] if candidate else CRYPTO_STRATEGIES,
+        "tol_pcts": [candidate.tol_pct] if candidate else TOL_PCTS,
+        "ma_lengths": MA_LENGTHS,
+        "ema_lengths": EMA_LENGTHS,
+        "bollinger_mas": BOLLINGER_MAS,
+        "bollinger_tols": [candidate.bollinger_sigma] if candidate else BOLLINGER_TOLS,
+        "buy_pcts": [candidate.buy_pct] if candidate else BUY_PCTS,
+        "sell_pcts": [candidate.sell_pct] if candidate else SELL_PCTS,
+        "buy_stas": BUY_STAS,
+        "sell_stas": SELL_STAS,
+        "rsi_periods": (
+            [candidate.rsi_period]
+            if candidate and candidate.rsi_period
+            else RSI_PERIODS
+        ),
+        "rsi_oversold_thresholds": (
+            [candidate.rsi_oversold]
+            if candidate and candidate.rsi_oversold is not None
+            else RSI_OVERSOLD_THRESHOLDS
+        ),
+        "rsi_overbought_thresholds": (
+            [candidate.rsi_overbought]
+            if candidate and candidate.rsi_overbought is not None
+            else RSI_OVERBOUGHT_THRESHOLDS
+        ),
+        "kdj_oversold_thresholds": (
+            [candidate.kdj_oversold]
+            if candidate and candidate.kdj_oversold is not None
+            else KDJ_OVERSOLD_THRESHOLDS
+        ),
+        "kdj_overbought_thresholds": (
+            [candidate.kdj_overbought]
+            if candidate and candidate.kdj_overbought is not None
+            else KDJ_OVERBOUGHT_THRESHOLDS
+        ),
+        "mode": "normal",
+        "execute_on_next_open": True,
+        "slippage_bps": slippage_bps,
+        "enable_options": False,
+    }
+
+
+def _train_candidates(
+    name: str,
+    data: Sequence[Sequence[Any]],
+    top_k: int,
+    slippage_bps: float,
+) -> list[tuple[Candidate, dict[str, float | int]]]:
+    driver = TraderDriver(**_driver_kwargs(name, slippage_bps=slippage_bps))
+    driver.feed_data(list(data))
+    ranked = [
+        (_candidate_from_trader(trader), _metrics(trader, data))
+        for trader in driver.traders
+    ]
+    ranked.sort(
+        key=lambda item: (item[1]["excess_return"], item[1]["strategy_return"]),
+        reverse=True,
+    )
+    return ranked[:top_k]
+
+
+def _evaluate_candidate(
+    name: str,
+    candidate: Candidate,
+    data: Sequence[Sequence[Any]],
+    warmup_data: Sequence[Sequence[Any]] | None = None,
+    slippage_bps: float = 10.0,
+) -> dict[str, float | int]:
+    warmup_data = warmup_data or []
+    combined_data = [*warmup_data, *data]
+    driver = TraderDriver(**_driver_kwargs(name, candidate, slippage_bps))
+    driver.feed_data(combined_data, warmup_points=len(warmup_data))
+    return _metrics(driver.traders[0], data)
+
+
+def run_symbol_walk_forward(
+    symbol: str,
+    data: Sequence[Sequence[Any]],
+    train_days: int = 365,
+    validation_days: int = 90,
+    test_days: int = 30,
+    purge_days: int = 7,
+    top_k: int = 10,
+    warmup_days: int = 35,
+    slippage_bps: float = 10.0,
+    max_folds: int | None = None,
+) -> dict[str, Any]:
+    """Tune only on train/validation data, then evaluate frozen parameters on test data."""
+    if top_k <= 0:
+        raise ValueError("top_k must be positive")
+    if warmup_days < 0:
+        raise ValueError("warmup_days cannot be negative")
+
+    folds = build_walk_forward_folds(
+        len(data), train_days, validation_days, test_days, purge_days
+    )
+    if max_folds is not None:
+        folds = folds[:max_folds]
+    if not folds:
+        raise ValueError(
+            f"Insufficient data for walk-forward windows: {len(data)} rows"
+        )
+
+    fold_results = []
+    for fold in folds:
+        train_data = data[fold.train_start : fold.train_end]
+        validation_data = data[fold.validation_start : fold.validation_end]
+        test_data = data[fold.test_start : fold.test_end]
+        validation_warmup = data[
+            max(
+                fold.validation_start - warmup_days, fold.train_start
+            ) : fold.validation_start
+        ]
+        test_warmup = data[
+            max(
+                fold.validation_end - warmup_days, fold.validation_start
+            ) : fold.test_start
+        ]
+
+        training_candidates = _train_candidates(symbol, train_data, top_k, slippage_bps)
+        validation_results = []
+        for candidate, train_metrics in training_candidates:
+            validation_metrics = _evaluate_candidate(
+                symbol,
+                candidate,
+                validation_data,
+                validation_warmup,
+                slippage_bps,
+            )
+            validation_results.append((candidate, train_metrics, validation_metrics))
+        candidate, train_metrics, validation_metrics = max(
+            validation_results,
+            key=lambda item: (
+                item[2]["excess_return"],
+                item[2]["strategy_return"],
+                item[1]["excess_return"],
+            ),
+        )
+
+        test_metrics = _evaluate_candidate(
+            symbol, candidate, test_data, test_warmup, slippage_bps
+        )
+        fold_results.append(
+            {
+                "fold": fold.fold,
+                "train": {
+                    "start": train_data[0][1],
+                    "end": train_data[-1][1],
+                    **train_metrics,
+                },
+                "validation": {
+                    "start": validation_data[0][1],
+                    "end": validation_data[-1][1],
+                    **validation_metrics,
+                },
+                "purge": {
+                    "start": data[fold.purge_start][1] if purge_days else None,
+                    "end": data[fold.purge_end - 1][1] if purge_days else None,
+                    "days": purge_days,
+                },
+                "indicator_warmup_days": warmup_days,
+                "test": {
+                    "start": test_data[0][1],
+                    "end": test_data[-1][1],
+                    **test_metrics,
+                },
+                "frozen_parameters": asdict(candidate),
+            }
+        )
+        print(
+            f"{symbol} fold {fold.fold}/{len(folds)}: "
+            f"test={test_data[0][1][:10]}..{test_data[-1][1][:10]}, "
+            f"strategy={test_metrics['strategy_return']:.2f}%, "
+            f"buy_hold={test_metrics['buy_hold_return']:.2f}%, "
+            f"excess={test_metrics['excess_return']:.2f}%"
+        )
+
+    strategy_returns = [item["test"]["strategy_return"] for item in fold_results]
+    benchmark_returns = [item["test"]["buy_hold_return"] for item in fold_results]
+    excess_returns = [item["test"]["excess_return"] for item in fold_results]
+    compounded_strategy = compound_returns(strategy_returns)
+    compounded_benchmark = compound_returns(benchmark_returns)
+    return {
+        "symbol": symbol,
+        "data_start": data[0][1],
+        "data_end": data[-1][1],
+        "data_rows": len(data),
+        "folds": fold_results,
+        "summary": {
+            "fold_count": len(fold_results),
+            "compounded_strategy_return": compounded_strategy,
+            "compounded_buy_hold_return": compounded_benchmark,
+            "compounded_excess_return": compounded_strategy - compounded_benchmark,
+            "mean_excess_return": sum(excess_returns) / len(excess_returns),
+            "excess_win_rate": sum(value > 0 for value in excess_returns)
+            / len(excess_returns),
+        },
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Strict daily walk-forward backtest")
+    parser.add_argument("--symbols", nargs="+", default=CURS)
+    parser.add_argument("--train-days", type=int, default=365)
+    parser.add_argument("--validation-days", type=int, default=90)
+    parser.add_argument("--test-days", type=int, default=30)
+    parser.add_argument("--purge-days", type=int, default=7)
+    parser.add_argument("--top-k", type=int, default=10)
+    parser.add_argument("--warmup-days", type=int, default=35)
+    parser.add_argument("--slippage-bps", type=float, default=10.0)
+    parser.add_argument("--max-folds", type=int)
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+
+    results = []
+    for symbol in args.symbols:
+        data = load_daily_data(symbol)
+        results.append(
+            run_symbol_walk_forward(
+                symbol=symbol.upper(),
+                data=data,
+                train_days=args.train_days,
+                validation_days=args.validation_days,
+                test_days=args.test_days,
+                purge_days=args.purge_days,
+                top_k=args.top_k,
+                warmup_days=args.warmup_days,
+                slippage_bps=args.slippage_bps,
+                max_folds=args.max_folds,
+            )
+        )
+
+    output = args.output or Path("artifacts/backtests") / (
+        f"walk_forward_{datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%SZ')}.json"
+    )
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(results, indent=2), encoding="utf-8")
+    print(f"Saved report: {output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/app/db/db_management.py
+++ b/app/db/db_management.py
@@ -1,6 +1,7 @@
 """
 Database management utilities for the cryptocurrency trading bot.
 """
+
 import argparse
 import os
 import sys
@@ -82,6 +83,56 @@ def clear_old_data(days: int = 365):
         return False
 
 
+def backfill_daily_data(symbols=None, days: int = 1095):
+    """Fetch completed daily candles and store them idempotently in the database."""
+    logger = get_logger(__name__)
+
+    try:
+        from core.config import CURS
+        from trading.binance_client import BinanceClient
+
+        client = BinanceClient()
+        requested_symbols = symbols or CURS
+        failures = []
+
+        for asset in requested_symbols:
+            pair = asset.upper()
+            if not pair.endswith("USDT"):
+                pair = f"{pair}USDT"
+
+            cache_key = f"{pair}__1d"
+            try:
+                data = client.get_historic_data(
+                    pair,
+                    use_cache=False,
+                    interval_hours=24,
+                    lookback_days=days,
+                )
+                if not data:
+                    raise RuntimeError("Binance returned no completed daily candles")
+
+                if not db_manager.store_historical_data(cache_key, data):
+                    raise RuntimeError("database store operation failed")
+
+                print(
+                    f"{cache_key}: stored {len(data)} rows "
+                    f"({data[0][1]} through {data[-1][1]})"
+                )
+            except Exception as exc:
+                failures.append(pair)
+                logger.error(f"Failed to backfill {pair}: {exc}")
+
+        if failures:
+            print(f"Backfill failed for: {', '.join(failures)}")
+            return False
+
+        print(f"Backfill completed for {len(requested_symbols)} symbols.")
+        return True
+    except Exception as exc:
+        logger.error(f"Failed to backfill daily data: {exc}")
+        return False
+
+
 def test_connection():
     """Test database connection."""
     logger = get_logger(__name__)
@@ -106,14 +157,20 @@ def main():
     )
     parser.add_argument(
         "command",
-        choices=["init", "drop", "stats", "clear", "test"],
+        choices=["init", "drop", "stats", "clear", "test", "backfill"],
         help="Command to execute",
     )
     parser.add_argument(
         "--days",
         type=int,
-        default=365,
-        help="Number of days to keep when clearing old data (default: 365)",
+        default=None,
+        help="Number of days (clear default: 365; backfill default: 1095)",
+    )
+
+    parser.add_argument(
+        "--symbols",
+        nargs="+",
+        help="Assets or USDT pairs to backfill (default: configured CURS)",
     )
 
     args = parser.parse_args()
@@ -136,11 +193,15 @@ def main():
         sys.exit(0)
 
     elif args.command == "clear":
-        success = clear_old_data(args.days)
+        success = clear_old_data(args.days or 365)
         sys.exit(0 if success else 1)
 
     elif args.command == "test":
         success = test_connection()
+        sys.exit(0 if success else 1)
+
+    elif args.command == "backfill":
+        success = backfill_daily_data(args.symbols, args.days or 1095)
         sys.exit(0 if success else 1)
 
 

--- a/app/trading/binance_client.py
+++ b/app/trading/binance_client.py
@@ -1,5 +1,5 @@
 import time
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any, List, Optional
 
 import numpy as np
@@ -37,7 +37,11 @@ class BinanceClient:
 
     @timer
     def get_historic_data(
-        self, symbol: str, use_cache: bool = True, interval_hours: Optional[float] = None
+        self,
+        symbol: str,
+        use_cache: bool = True,
+        interval_hours: Optional[float] = None,
+        lookback_days: Optional[int] = None,
     ) -> list:
         """
         Get historical klines for a symbol with configurable interval, with database caching.
@@ -46,6 +50,7 @@ class BinanceClient:
             symbol (str): The trading pair symbol (e.g., 'BTCUSDT').
             use_cache (bool): Whether to use cached data if available and fresh.
             interval_hours (Optional[float]): Interval in hours. Defaults to DATA_INTERVAL_HOURS.
+            lookback_days (Optional[int]): Number of UTC calendar days to fetch. Defaults to TIMESPAN.
         Returns:
             list: Each element is [closing_price, datetime_str, open_price, low, high, volume].
         Raises:
@@ -55,7 +60,13 @@ class BinanceClient:
         # The current DB schema uses (symbol, date) as the uniqueness key. If we store multiple
         # granularities (e.g., 12h vs 30m) under the same symbol, rows will collide/overwrite.
         # To avoid corrupting cached data, we only use DB cache for the original hour-based intervals.
-        interval_base = DATA_INTERVAL_HOURS if interval_hours is None else interval_hours
+        requested_days = TIMESPAN if lookback_days is None else int(lookback_days)
+        if requested_days <= 0:
+            raise ValueError(f"lookback_days must be positive, got {requested_days}")
+
+        interval_base = (
+            DATA_INTERVAL_HOURS if interval_hours is None else interval_hours
+        )
         interval_minutes = int(round(float(interval_base) * 60))
 
         def _binance_interval_str(minutes: int) -> str:
@@ -91,13 +102,15 @@ class BinanceClient:
         fetch_interval_minutes = 5 if wants_resample_10m else interval_minutes
         interval_str = _binance_interval_str(fetch_interval_minutes)
 
-        cache_allowed = fetch_interval_minutes in (60, 360, 720, 1440) and not wants_resample_10m
+        cache_allowed = (
+            fetch_interval_minutes in (60, 360, 720, 1440) and not wants_resample_10m
+        )
         # IMPORTANT: DB uniqueness is (symbol, date). If DATA_INTERVAL_HOURS changes (e.g. 12h -> 6h),
         # cached rows can silently mismatch the requested granularity. Use an interval-specific cache key.
         cache_key = f"{symbol}__{interval_str}"
 
         if use_cache and cache_allowed:
-            cached_data = db_manager.get_historical_data(cache_key, TIMESPAN)
+            cached_data = db_manager.get_historical_data(cache_key, requested_days)
             if cached_data and db_manager.is_data_fresh(cache_key, max_age_hours=72):
                 self.logger.info(
                     f"Using cached data for {symbol} ({len(cached_data)} records, interval={interval_str})"
@@ -119,10 +132,13 @@ class BinanceClient:
 
         try:
             end = int(time.time() * 1000)
-            start = int(
-                (datetime.utcnow() - timedelta(days=TIMESPAN)).timestamp() * 1000
+            start_dt = datetime.now(timezone.utc).replace(
+                hour=0, minute=0, second=0, microsecond=0
             )
-            self.logger.info(f"Fetching klines for {symbol} from {datetime.utcfromtimestamp(start/1000).strftime('%Y-%m-%d %H:%M:%S')} to {datetime.utcfromtimestamp(end/1000).strftime('%Y-%m-%d %H:%M:%S')}")
+            start = int((start_dt - timedelta(days=requested_days)).timestamp() * 1000)
+            self.logger.info(
+                f"Fetching klines for {symbol} from {datetime.utcfromtimestamp(start/1000).strftime('%Y-%m-%d %H:%M:%S')} to {datetime.utcfromtimestamp(end/1000).strftime('%Y-%m-%d %H:%M:%S')}"
+            )
 
             # Binance returns limited klines per request; paginate to cover long timespans.
             def _fetch_klines_paginated(
@@ -154,11 +170,13 @@ class BinanceClient:
                     time.sleep(0.05)
                 return out
 
-            klines = _fetch_klines_paginated(symbol, interval_str, start, end, limit=1000)
+            klines = _fetch_klines_paginated(
+                symbol, interval_str, start, end, limit=1000
+            )
             self.logger.info(
                 f"Received {len(klines)} klines from API for {symbol} (interval: {interval_str})"
             )
-            
+
             if not klines:
                 self.logger.warning(f"No klines returned from API for {symbol}")
                 return []
@@ -186,7 +204,9 @@ class BinanceClient:
                     dt_obj = datetime.strptime(dt_str, "%Y-%m-%d %H:%M:%S")
                     # floor to 10-minute boundary
                     floored_minute = (dt_obj.minute // 10) * 10
-                    bucket = dt_obj.replace(minute=floored_minute, second=0, microsecond=0)
+                    bucket = dt_obj.replace(
+                        minute=floored_minute, second=0, microsecond=0
+                    )
                     key = bucket.strftime("%Y-%m-%d %H:%M:%S")
                     if key not in grouped:
                         grouped[key] = {
@@ -219,9 +239,11 @@ class BinanceClient:
             cutoff_time = now - timedelta(minutes=interval_minutes)
             cutoff_str = cutoff_time.strftime("%Y-%m-%d %H:%M:%S")
             parsed = [x for x in parsed if x[1] < cutoff_str]
-            
-            self.logger.info(f"Processed {len(parsed)} data points for {symbol} after filtering")
-            
+
+            self.logger.info(
+                f"Processed {len(parsed)} data points for {symbol} after filtering"
+            )
+
             if use_cache and cache_allowed and parsed:
                 db_manager.store_historical_data(cache_key, parsed)
             return parsed

--- a/app/trading/strat_trader.py
+++ b/app/trading/strat_trader.py
@@ -25,7 +25,6 @@ from app.utils.util import ema_helper, max_drawdown_helper
 
 
 class StratTrader:
-
     """Moving Average Trader, a strategic-trading implementation that focus and relies on moving averages."""
 
     def __init__(
@@ -51,6 +50,9 @@ class StratTrader:
         zoom_in: bool = False,
         zoom_in_min_move_pct: float = 0.003,
         ma_boll_simplify: bool = False,
+        execute_on_next_open: bool = False,
+        slippage_bps: float = 0.0,
+        enable_options: bool = True,
         mode: str = "normal",
     ):
         """
@@ -146,10 +148,24 @@ class StratTrader:
         self.zoom_in = zoom_in
         self.zoom_in_min_move_pct = zoom_in_min_move_pct
         self.ma_boll_simplify = ma_boll_simplify
+        self.execute_on_next_open = execute_on_next_open
+        self.slippage_bps = float(slippage_bps)
+        if self.slippage_bps < 0:
+            raise ValueError("slippage_bps cannot be negative")
+        self.enable_options = enable_options
+        self.pending_order = None
+        self.signal_history = []
+        self._executing_pending_order = False
         # strategy signal lists
         self.strat_dct = collections.defaultdict(list)
 
-    def add_new_day(self, new_p: float, d: datetime.datetime, misc_p: dict):
+    def add_new_day(
+        self,
+        new_p: float,
+        d: datetime.datetime,
+        misc_p: dict,
+        execute_strategy: bool = True,
+    ):
         """
         Add a new day's crypto-currency price, find out a computed transaction for today.
 
@@ -157,6 +173,7 @@ class StratTrader:
             new_p (float): New price.
             d (datetime.datetime): Date.
             misc_p (dict): Miscellaneous price info (open, low, high).
+            execute_strategy (bool): Update indicators but suppress trades when False.
 
         Returns:
             None
@@ -181,6 +198,14 @@ class StratTrader:
 
         # compute KDJ related arrays
         self.compute_kdj_related(d=d, low=low, high=high, open=open, close=new_p)
+
+        if execute_strategy:
+            self._execute_pending_order(open_price=open, d=d)
+
+        # Walk-forward tests use earlier candles only to warm indicators. No strategy
+        # decision, option settlement, or portfolio mutation is allowed before the test.
+        if not execute_strategy:
+            return
 
         # Settle any expired options before executing new strategy logic.
         self._settle_expired_options(new_p=new_p, d=d)
@@ -620,6 +645,10 @@ class StratTrader:
                 print("no more cash left, cannot buy anymore!")
             return False
 
+        if self.execute_on_next_open and not self._executing_pending_order:
+            self.pending_order = {"action": BUY_SIGNAL, "method": method}
+            return True
+
         # execution body
         if method == "by_percentage":
             # Use percentage of available cash
@@ -666,6 +695,10 @@ class StratTrader:
             if self.mode == "verbose":
                 print("no coin left, cannot sell anymore!")
             return False
+
+        if self.execute_on_next_open and not self._executing_pending_order:
+            self.pending_order = {"action": SELL_SIGNAL, "method": method}
+            return True
 
         # execution body
         if method == "by_percentage":
@@ -724,6 +757,15 @@ class StratTrader:
         Returns:
             None
         """
+        if (
+            self.execute_on_next_open
+            and not self._executing_pending_order
+            and self.pending_order
+            and self.pending_order["action"] == action
+        ):
+            self.signal_history.append({"action": action, "price": new_p, "date": d})
+            return
+
         item = {
             "action": action,
             "price": new_p,
@@ -736,6 +778,29 @@ class StratTrader:
 
         if self.mode == "verbose":
             print(item)
+
+    def _execute_pending_order(self, open_price: float, d: datetime.datetime) -> None:
+        """Execute a prior-close signal at today's open with adverse slippage."""
+        if not self.execute_on_next_open or not self.pending_order:
+            return
+
+        order = self.pending_order
+        self.pending_order = None
+        action = order["action"]
+        slip = self.slippage_bps / 10_000.0
+        execution_price = float(open_price) * (
+            1.0 + slip if action == BUY_SIGNAL else 1.0 - slip
+        )
+        self._executing_pending_order = True
+        try:
+            if action == BUY_SIGNAL:
+                success = self._execute_one_buy(order["method"], execution_price)
+            else:
+                success = self._execute_one_sell(order["method"], execution_price)
+            if success:
+                self._record_history(execution_price, d, action)
+        finally:
+            self._executing_pending_order = False
 
     def _settle_expired_options(self, new_p: float, d: datetime.datetime) -> None:
         """
@@ -920,26 +985,30 @@ class StratTrader:
             final_price = self.crypto_prices[-1][0]
             init_p = self.init_coin * init_price + self.init_cash
             final_p = self.init_coin * final_price + self.init_cash
-            
+
             # Handle division by zero
             if init_p == 0:
                 if final_p == 0:
                     return 0.0  # No change if both initial and final are zero
                 else:
-                    return float('inf') if final_p > 0 else float('-inf')  # Infinite return if starting from zero
-            
+                    return (
+                        float("inf") if final_p > 0 else float("-inf")
+                    )  # Infinite return if starting from zero
+
             return np.round(100 * (final_p - init_p) / init_p, ROUND_PRECISION)
         else:
             init_p = self.all_history[0]["portfolio"]
             final_p = self.init_coin * self.all_history[-1]["price"] + self.init_cash
-            
+
             # Handle division by zero
             if init_p == 0:
                 if final_p == 0:
                     return 0.0  # No change if both initial and final are zero
                 else:
-                    return float('inf') if final_p > 0 else float('-inf')  # Infinite return if starting from zero
-            
+                    return (
+                        float("inf") if final_p > 0 else float("-inf")
+                    )  # Infinite return if starting from zero
+
             return np.round(100 * (final_p - init_p) / init_p, ROUND_PRECISION)
 
     @property
@@ -955,8 +1024,10 @@ class StratTrader:
             if final_p == 0:
                 return 0.0  # No change if both initial and final are zero
             else:
-                return float('inf') if final_p > 0 else float('-inf')  # Infinite return if starting from zero
-        
+                return (
+                    float("inf") if final_p > 0 else float("-inf")
+                )  # Infinite return if starting from zero
+
         return np.round(100 * (final_p - init_p) / init_p, ROUND_PRECISION)
 
     @property
@@ -968,29 +1039,37 @@ class StratTrader:
                 return 0.0  # Not enough price data
             init_price = self.crypto_prices[0][0]
             final_price = self.crypto_prices[-1][0]
-            
+
             # Handle division by zero
             if init_price == 0:
                 if final_price == 0:
                     return 0.0  # No change if both initial and final are zero
                 else:
-                    return float('inf') if final_price > 0 else float('-inf')  # Infinite return if starting from zero
-            
-            return np.round(100 * (final_price - init_price) / init_price, ROUND_PRECISION)
+                    return (
+                        float("inf") if final_price > 0 else float("-inf")
+                    )  # Infinite return if starting from zero
+
+            return np.round(
+                100 * (final_price - init_price) / init_price, ROUND_PRECISION
+            )
         else:
             init_price, final_price = (
                 self.all_history[0]["price"],
                 self.all_history[-1]["price"],
             )
-            
+
             # Handle division by zero
             if init_price == 0:
                 if final_price == 0:
                     return 0.0  # No change if both initial and final are zero
                 else:
-                    return float('inf') if final_price > 0 else float('-inf')  # Infinite return if starting from zero
-            
-            return np.round(100 * (final_price - init_price) / init_price, ROUND_PRECISION)
+                    return (
+                        float("inf") if final_price > 0 else float("-inf")
+                    )  # Infinite return if starting from zero
+
+            return np.round(
+                100 * (final_price - init_price) / init_price, ROUND_PRECISION
+            )
 
     @property
     def trade_signal(self):

--- a/app/trading/strategies.py
+++ b/app/trading/strategies.py
@@ -189,7 +189,7 @@ def apply_signal_option_leverage(
     Returns:
         Optional[Dict]: The recorded option trade dict, or None if skipped.
     """
-    if not enabled:
+    if not enabled or not getattr(trader, "enable_options", True):
         return None
 
     if signal not in (BUY_SIGNAL, SELL_SIGNAL):

--- a/app/trading/trader_driver.py
+++ b/app/trading/trader_driver.py
@@ -19,11 +19,13 @@ from app.core.config import (
 )
 from app.trading.strat_trader import StratTrader
 from app.utils.util import timer
+
 try:
     from app.core.logger import get_logger
 except ImportError:
     import os
     import sys
+
     sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
     from core.logger import get_logger
 
@@ -31,7 +33,6 @@ logger = get_logger(__name__)
 
 
 class TraderDriver:
-
     """A wrapper class on top of any of trader classes."""
 
     @staticmethod
@@ -62,7 +63,11 @@ class TraderDriver:
 
         # Adjust for strategies that expand the grid (RSI/KDJ)
         # Our unified grid counts RSI/KDJ once each; replace that "1" with their extra grid sizes.
-        rsi_extra = len(rsi_periods) * len(rsi_oversold_thresholds) * len(rsi_overbought_thresholds)
+        rsi_extra = (
+            len(rsi_periods)
+            * len(rsi_oversold_thresholds)
+            * len(rsi_overbought_thresholds)
+        )
         kdj_extra = len(kdj_oversold_thresholds) * len(kdj_overbought_thresholds)
 
         n_stats = len(overall_stats)
@@ -80,7 +85,9 @@ class TraderDriver:
             else:
                 per_combo += 1
 
-        combos_without_strategy = len(bollinger_tols) * len(tol_pcts) * len(buy_pcts) * len(sell_pcts)
+        combos_without_strategy = (
+            len(bollinger_tols) * len(tol_pcts) * len(buy_pcts) * len(sell_pcts)
+        )
         return combos_without_strategy * per_combo
 
     @staticmethod
@@ -182,6 +189,9 @@ class TraderDriver:
         zoom_in: bool = False,
         zoom_in_min_move_pct: float = 0.003,
         ma_boll_simplify: bool = True,
+        execute_on_next_open: bool = False,
+        slippage_bps: float = 0.0,
+        enable_options: bool = True,
         mode: str = "normal",
     ):
         """
@@ -249,6 +259,9 @@ class TraderDriver:
                 zoom_in=zoom_in,
                 zoom_in_min_move_pct=zoom_in_min_move_pct,
                 ma_boll_simplify=ma_boll_simplify,
+                execute_on_next_open=execute_on_next_open,
+                slippage_bps=slippage_bps,
+                enable_options=enable_options,
             )
             self.traders.append(t)
 
@@ -272,7 +285,9 @@ class TraderDriver:
 
         # Sanity check: ensure we created at least one trader.
         if len(self.traders) == 0:
-            raise ValueError("No traders were created. Check your parameter grids and overall_stats.")
+            raise ValueError(
+                "No traders were created. Check your parameter grids and overall_stats."
+            )
         # unknown, without data
         self.best_trader = None
 
@@ -295,6 +310,7 @@ class TraderDriver:
         data_stream: List[tuple],
         intraday_stream: Optional[List[tuple]] = None,
         intraday_interval_hours: int = 1,
+        warmup_points: int = 0,
     ):
         """
         Feed in historic data, where data_stream consists of tuples of (price, date, open, low, high).
@@ -305,6 +321,7 @@ class TraderDriver:
             intraday_stream (Optional[List[tuple]]): Optional lower-granularity candles (e.g., 1h)
                 to support zoom-in logic. Same tuple format as data_stream.
             intraday_interval_hours (int): Expected intraday interval in hours. Defaults to 1.
+            warmup_points (int): Leading rows used only for indicators; trading is disabled.
 
         Returns:
             None
@@ -317,13 +334,21 @@ class TraderDriver:
 
         # Validate data stream
         if not data_stream:
-            raise ValueError("Data stream is empty - no historical data available for simulation")
-        
+            raise ValueError(
+                "Data stream is empty - no historical data available for simulation"
+            )
+
         if len(data_stream) < 2:
-            raise ValueError(f"Data stream has insufficient data points ({len(data_stream)}). Need at least 2 data points for simulation.")
+            raise ValueError(
+                f"Data stream has insufficient data points ({len(data_stream)}). Need at least 2 data points for simulation."
+            )
+        if warmup_points < 0 or warmup_points >= len(data_stream):
+            raise ValueError("warmup_points must be >= 0 and smaller than data_stream")
 
         # Log data feed details
-        logger.info(f"[{self.name}] Feeding {len(data_stream)} data points to {len(self.traders)} traders")
+        logger.info(
+            f"[{self.name}] Feeding {len(data_stream)} data points to {len(self.traders)} traders"
+        )
         if len(data_stream) > 0:
             try:
                 start_date = data_stream[0][1]
@@ -334,7 +359,9 @@ class TraderDriver:
                 if prices:
                     min_price = min(prices)
                     max_price = max(prices)
-                    logger.info(f"[{self.name}] Price range: ${min_price:.2f} - ${max_price:.2f}")
+                    logger.info(
+                        f"[{self.name}] Price range: ${min_price:.2f} - ${max_price:.2f}"
+                    )
             except Exception as e:
                 logger.debug(f"[{self.name}] Could not extract data range info: {e}")
 
@@ -368,15 +395,17 @@ class TraderDriver:
                     continue
                 intraday_items.append((dt, item))
             intraday_items.sort(key=lambda x: x[0])
-        
-        logger.debug(f"[{self.name}] Processing {num_traders} trading strategies across {len(data_stream)} data points")
+
+        logger.debug(
+            f"[{self.name}] Processing {num_traders} trading strategies across {len(data_stream)} data points"
+        )
 
         for index, t in enumerate(self.traders):
             trader_start_time = time.perf_counter()
 
             intraday_idx = 0
             prev_dt = None
-            
+
             # compute initial value
             date_obj = parse_date(data_stream[0][1])
             intraday_slice = []
@@ -399,10 +428,12 @@ class TraderDriver:
                     "intraday_interval_hours": intraday_interval_hours,
                     **(
                         {"volume": data_stream[0][5]}
-                        if isinstance(data_stream[0], (list, tuple)) and len(data_stream[0]) > 5
+                        if isinstance(data_stream[0], (list, tuple))
+                        and len(data_stream[0]) > 5
                         else {}
                     ),
                 },
+                execute_strategy=warmup_points == 0,
             )
             prev_dt = date_obj
             # run simulation
@@ -427,11 +458,17 @@ class TraderDriver:
                     "intraday_interval_hours": intraday_interval_hours,
                     **(
                         {"volume": data_stream[i][5]}
-                        if isinstance(data_stream[i], (list, tuple)) and len(data_stream[i]) > 5
+                        if isinstance(data_stream[i], (list, tuple))
+                        and len(data_stream[i]) > 5
                         else {}
                     ),
                 }
-                t.add_new_day(p, d, misc_p)
+                t.add_new_day(
+                    p,
+                    d,
+                    misc_p,
+                    execute_strategy=i >= warmup_points,
+                )
                 prev_dt = d
             # decide best trader while we loop, by comparing all traders final portfolio value
             # sometimes a trader makes no trade at all
@@ -447,19 +484,23 @@ class TraderDriver:
                 print('Found error!', t.high_strategy)
             """
             trader_process_time = time.perf_counter() - trader_start_time
-            
+
             # Log trader performance summary (every 10 traders to avoid too much output)
             if (index + 1) % 10 == 0 or index == num_traders - 1:
-                logger.debug(f"[{self.name}] Processed {index + 1}/{num_traders} traders "
-                           f"(strategy: {t.high_strategy}, final_value: ${tmp_final_p:.2f}, "
-                           f"time: {trader_process_time:.3f}s)")
-            
+                logger.debug(
+                    f"[{self.name}] Processed {index + 1}/{num_traders} traders "
+                    f"(strategy: {t.high_strategy}, final_value: ${tmp_final_p:.2f}, "
+                    f"time: {trader_process_time:.3f}s)"
+                )
+
             if tmp_final_p >= max_final_p:
                 max_final_p = tmp_final_p
                 self.best_trader = t
-        
-        logger.info(f"[{self.name}] Completed feed_data: Best trader strategy={self.best_trader.high_strategy}, "
-                    f"final_value=${max_final_p:.2f}")
+
+        logger.info(
+            f"[{self.name}] Completed feed_data: Best trader strategy={self.best_trader.high_strategy}, "
+            f"final_value=${max_final_p:.2f}"
+        )
 
     @property
     def best_trader_info(self):

--- a/artifacts/backtests/btc_walk_forward_full.json
+++ b/artifacts/backtests/btc_walk_forward_full.json
@@ -1,0 +1,1026 @@
+[
+  {
+    "symbol": "BTC",
+    "data_start": "2023-08-04 00:00:00",
+    "data_end": "2026-08-02 00:00:00",
+    "data_rows": 1095,
+    "folds": [
+      {
+        "fold": 1,
+        "train": {
+          "start": "2023-08-04 00:00:00",
+          "end": "2024-08-02 00:00:00",
+          "strategy_return": 85.677,
+          "buy_hold_return": 111.23291585935146,
+          "excess_return": -25.555915859351458,
+          "max_drawdown": 24.88,
+          "transactions": 107
+        },
+        "validation": {
+          "start": "2024-08-03 00:00:00",
+          "end": "2024-10-31 00:00:00",
+          "strategy_return": 7.119,
+          "buy_hold_return": 15.806157666835418,
+          "excess_return": -8.687157666835418,
+          "max_drawdown": 8.4,
+          "transactions": 12
+        },
+        "purge": {
+          "start": "2024-11-01 00:00:00",
+          "end": "2024-11-07 00:00:00",
+          "days": 7
+        },
+        "indicator_warmup_days": 35,
+        "test": {
+          "start": "2024-11-08 00:00:00",
+          "end": "2024-12-07 00:00:00",
+          "strategy_return": 19.716,
+          "buy_hold_return": 30.48265202174154,
+          "excess_return": -10.766652021741539,
+          "max_drawdown": 7.580000000000001,
+          "transactions": 15
+        },
+        "frozen_parameters": {
+          "strategy": "MA-BOLL-BANDS",
+          "tol_pct": 0.2,
+          "buy_pct": 0.9,
+          "sell_pct": 0.1,
+          "bollinger_sigma": 5.0,
+          "rsi_period": null,
+          "rsi_oversold": null,
+          "rsi_overbought": null,
+          "kdj_oversold": null,
+          "kdj_overbought": null
+        }
+      },
+      {
+        "fold": 2,
+        "train": {
+          "start": "2023-09-03 00:00:00",
+          "end": "2024-09-01 00:00:00",
+          "strategy_return": 79.218,
+          "buy_hold_return": 120.63608126074988,
+          "excess_return": -41.41808126074987,
+          "max_drawdown": 27.389999999999997,
+          "transactions": 110
+        },
+        "validation": {
+          "start": "2024-09-02 00:00:00",
+          "end": "2024-11-30 00:00:00",
+          "strategy_return": 40.245,
+          "buy_hold_return": 63.03825010193276,
+          "excess_return": -22.793250101932763,
+          "max_drawdown": 8.18,
+          "transactions": 28
+        },
+        "purge": {
+          "start": "2024-12-01 00:00:00",
+          "end": "2024-12-07 00:00:00",
+          "days": 7
+        },
+        "indicator_warmup_days": 35,
+        "test": {
+          "start": "2024-12-08 00:00:00",
+          "end": "2025-01-06 00:00:00",
+          "strategy_return": -7.047,
+          "buy_hold_return": 1.1136530174833181,
+          "excess_return": -8.160653017483318,
+          "max_drawdown": 8.18,
+          "transactions": 8
+        },
+        "frozen_parameters": {
+          "strategy": "MA-BOLL-BANDS",
+          "tol_pct": 0.2,
+          "buy_pct": 0.9,
+          "sell_pct": 0.1,
+          "bollinger_sigma": 4.0,
+          "rsi_period": null,
+          "rsi_oversold": null,
+          "rsi_overbought": null,
+          "kdj_oversold": null,
+          "kdj_overbought": null
+        }
+      },
+      {
+        "fold": 3,
+        "train": {
+          "start": "2023-10-03 00:00:00",
+          "end": "2024-10-01 00:00:00",
+          "strategy_return": 47.628,
+          "buy_hold_return": 121.70480623456328,
+          "excess_return": -74.07680623456328,
+          "max_drawdown": 27.389999999999997,
+          "transactions": 105
+        },
+        "validation": {
+          "start": "2024-10-02 00:00:00",
+          "end": "2024-12-30 00:00:00",
+          "strategy_return": 28.886,
+          "buy_hold_return": 52.997776725461556,
+          "excess_return": -24.111776725461556,
+          "max_drawdown": 7.62,
+          "transactions": 33
+        },
+        "purge": {
+          "start": "2024-12-31 00:00:00",
+          "end": "2025-01-06 00:00:00",
+          "days": 7
+        },
+        "indicator_warmup_days": 35,
+        "test": {
+          "start": "2025-01-07 00:00:00",
+          "end": "2025-02-05 00:00:00",
+          "strategy_return": -5.687,
+          "buy_hold_return": -0.3529280350877628,
+          "excess_return": -5.334071964912237,
+          "max_drawdown": 7.86,
+          "transactions": 6
+        },
+        "frozen_parameters": {
+          "strategy": "MA-BOLL-BANDS",
+          "tol_pct": 0.2,
+          "buy_pct": 0.9,
+          "sell_pct": 0.1,
+          "bollinger_sigma": 4.0,
+          "rsi_period": null,
+          "rsi_oversold": null,
+          "rsi_overbought": null,
+          "kdj_oversold": null,
+          "kdj_overbought": null
+        }
+      },
+      {
+        "fold": 4,
+        "train": {
+          "start": "2023-11-02 00:00:00",
+          "end": "2024-10-31 00:00:00",
+          "strategy_return": 48.626,
+          "buy_hold_return": 101.17003834112874,
+          "excess_return": -52.54403834112875,
+          "max_drawdown": 29.299999999999997,
+          "transactions": 94
+        },
+        "validation": {
+          "start": "2024-11-01 00:00:00",
+          "end": "2025-01-29 00:00:00",
+          "strategy_return": 33.708,
+          "buy_hold_return": 49.265029747751,
+          "excess_return": -15.557029747751002,
+          "max_drawdown": 11.08,
+          "transactions": 36
+        },
+        "purge": {
+          "start": "2025-01-30 00:00:00",
+          "end": "2025-02-05 00:00:00",
+          "days": 7
+        },
+        "indicator_warmup_days": 35,
+        "test": {
+          "start": "2025-02-06 00:00:00",
+          "end": "2025-03-07 00:00:00",
+          "strategy_return": 0.0,
+          "buy_hold_return": -10.100632441728418,
+          "excess_return": 10.100632441728418,
+          "max_drawdown": 0.0,
+          "transactions": 0
+        },
+        "frozen_parameters": {
+          "strategy": "MA-BOLL-BANDS",
+          "tol_pct": 0.2,
+          "buy_pct": 0.9,
+          "sell_pct": 0.1,
+          "bollinger_sigma": 5.0,
+          "rsi_period": null,
+          "rsi_oversold": null,
+          "rsi_overbought": null,
+          "kdj_oversold": null,
+          "kdj_overbought": null
+        }
+      },
+      {
+        "fold": 5,
+        "train": {
+          "start": "2023-12-02 00:00:00",
+          "end": "2024-11-30 00:00:00",
+          "strategy_return": 80.743,
+          "buy_hold_return": 144.37803466889397,
+          "excess_return": -63.63503466889398,
+          "max_drawdown": 29.299999999999997,
+          "transactions": 94
+        },
+        "validation": {
+          "start": "2024-12-01 00:00:00",
+          "end": "2025-02-28 00:00:00",
+          "strategy_return": -16.234,
+          "buy_hold_return": -13.206993082690166,
+          "excess_return": -3.0270069173098353,
+          "max_drawdown": 19.86,
+          "transactions": 22
+        },
+        "purge": {
+          "start": "2025-03-01 00:00:00",
+          "end": "2025-03-07 00:00:00",
+          "days": 7
+        },
+        "indicator_warmup_days": 35,
+        "test": {
+          "start": "2025-03-08 00:00:00",
+          "end": "2025-04-06 00:00:00",
+          "strategy_return": -6.039,
+          "buy_hold_return": -9.037611434145044,
+          "excess_return": 2.998611434145044,
+          "max_drawdown": 7.12,
+          "transactions": 1
+        },
+        "frozen_parameters": {
+          "strategy": "MA-BOLL-BANDS",
+          "tol_pct": 0.2,
+          "buy_pct": 0.9,
+          "sell_pct": 0.1,
+          "bollinger_sigma": 5.0,
+          "rsi_period": null,
+          "rsi_oversold": null,
+          "rsi_overbought": null,
+          "kdj_oversold": null,
+          "kdj_overbought": null
+        }
+      },
+      {
+        "fold": 6,
+        "train": {
+          "start": "2024-01-01 00:00:00",
+          "end": "2024-12-30 00:00:00",
+          "strategy_return": 80.372,
+          "buy_hold_return": 110.03394104285805,
+          "excess_return": -29.661941042858047,
+          "max_drawdown": 29.299999999999997,
+          "transactions": 101
+        },
+        "validation": {
+          "start": "2024-12-31 00:00:00",
+          "end": "2025-03-30 00:00:00",
+          "strategy_return": -20.761,
+          "buy_hold_return": -11.95393049499871,
+          "excess_return": -8.807069505001289,
+          "max_drawdown": 25.0,
+          "transactions": 10
+        },
+        "purge": {
+          "start": "2025-03-31 00:00:00",
+          "end": "2025-04-06 00:00:00",
+          "days": 7
+        },
+        "indicator_warmup_days": 35,
+        "test": {
+          "start": "2025-04-07 00:00:00",
+          "end": "2025-05-06 00:00:00",
+          "strategy_return": 9.105,
+          "buy_hold_return": 22.32195145120386,
+          "excess_return": -13.216951451203858,
+          "max_drawdown": 3.17,
+          "transactions": 10
+        },
+        "frozen_parameters": {
+          "strategy": "MA-BOLL-BANDS",
+          "tol_pct": 0.2,
+          "buy_pct": 0.9,
+          "sell_pct": 0.1,
+          "bollinger_sigma": 5.0,
+          "rsi_period": null,
+          "rsi_oversold": null,
+          "rsi_overbought": null,
+          "kdj_oversold": null,
+          "kdj_overbought": null
+        }
+      },
+      {
+        "fold": 7,
+        "train": {
+          "start": "2024-01-31 00:00:00",
+          "end": "2025-01-29 00:00:00",
+          "strategy_return": 59.229,
+          "buy_hold_return": 143.61963363081261,
+          "excess_return": -84.39063363081262,
+          "max_drawdown": 28.58,
+          "transactions": 114
+        },
+        "validation": {
+          "start": "2025-01-30 00:00:00",
+          "end": "2025-04-29 00:00:00",
+          "strategy_return": 6.337,
+          "buy_hold_return": -9.994104443591823,
+          "excess_return": 16.331104443591823,
+          "max_drawdown": 9.35,
+          "transactions": 8
+        },
+        "purge": {
+          "start": "2025-04-30 00:00:00",
+          "end": "2025-05-06 00:00:00",
+          "days": 7
+        },
+        "indicator_warmup_days": 35,
+        "test": {
+          "start": "2025-05-07 00:00:00",
+          "end": "2025-06-05 00:00:00",
+          "strategy_return": -3.59,
+          "buy_hold_return": 4.615229232045581,
+          "excess_return": -8.205229232045582,
+          "max_drawdown": 7.580000000000001,
+          "transactions": 9
+        },
+        "frozen_parameters": {
+          "strategy": "MA-BOLL-BANDS",
+          "tol_pct": 0.2,
+          "buy_pct": 0.9,
+          "sell_pct": 0.1,
+          "bollinger_sigma": 3.0,
+          "rsi_period": null,
+          "rsi_oversold": null,
+          "rsi_overbought": null,
+          "kdj_oversold": null,
+          "kdj_overbought": null
+        }
+      },
+      {
+        "fold": 8,
+        "train": {
+          "start": "2024-03-01 00:00:00",
+          "end": "2025-02-28 00:00:00",
+          "strategy_return": 6.761,
+          "buy_hold_return": 35.202403030074734,
+          "excess_return": -28.441403030074735,
+          "max_drawdown": 25.119999999999997,
+          "transactions": 83
+        },
+        "validation": {
+          "start": "2025-03-01 00:00:00",
+          "end": "2025-05-29 00:00:00",
+          "strategy_return": 10.142,
+          "buy_hold_return": 22.68672123115063,
+          "excess_return": -12.544721231150632,
+          "max_drawdown": 8.14,
+          "transactions": 24
+        },
+        "purge": {
+          "start": "2025-05-30 00:00:00",
+          "end": "2025-06-05 00:00:00",
+          "days": 7
+        },
+        "indicator_warmup_days": 35,
+        "test": {
+          "start": "2025-06-06 00:00:00",
+          "end": "2025-07-05 00:00:00",
+          "strategy_return": -1.155,
+          "buy_hold_return": 3.7489102339626434,
+          "excess_return": -4.903910233962644,
+          "max_drawdown": 1.25,
+          "transactions": 2
+        },
+        "frozen_parameters": {
+          "strategy": "MA-BOLL-BANDS",
+          "tol_pct": 0.2,
+          "buy_pct": 0.3,
+          "sell_pct": 0.1,
+          "bollinger_sigma": 5.0,
+          "rsi_period": null,
+          "rsi_oversold": null,
+          "rsi_overbought": null,
+          "kdj_oversold": null,
+          "kdj_overbought": null
+        }
+      },
+      {
+        "fold": 9,
+        "train": {
+          "start": "2024-03-31 00:00:00",
+          "end": "2025-03-30 00:00:00",
+          "strategy_return": 5.882,
+          "buy_hold_return": 15.586389508082288,
+          "excess_return": -9.704389508082288,
+          "max_drawdown": 26.14,
+          "transactions": 78
+        },
+        "validation": {
+          "start": "2025-03-31 00:00:00",
+          "end": "2025-06-28 00:00:00",
+          "strategy_return": 17.632,
+          "buy_hold_return": 29.977924896677788,
+          "excess_return": -12.345924896677786,
+          "max_drawdown": 7.7299999999999995,
+          "transactions": 25
+        },
+        "purge": {
+          "start": "2025-06-29 00:00:00",
+          "end": "2025-07-05 00:00:00",
+          "days": 7
+        },
+        "indicator_warmup_days": 35,
+        "test": {
+          "start": "2025-07-06 00:00:00",
+          "end": "2025-08-04 00:00:00",
+          "strategy_return": 1.53,
+          "buy_hold_return": 5.358044185991995,
+          "excess_return": -3.8280441859919945,
+          "max_drawdown": 6.15,
+          "transactions": 9
+        },
+        "frozen_parameters": {
+          "strategy": "MA-BOLL-BANDS",
+          "tol_pct": 0.2,
+          "buy_pct": 0.9,
+          "sell_pct": 0.1,
+          "bollinger_sigma": 5.0,
+          "rsi_period": null,
+          "rsi_oversold": null,
+          "rsi_overbought": null,
+          "kdj_oversold": null,
+          "kdj_overbought": null
+        }
+      },
+      {
+        "fold": 10,
+        "train": {
+          "start": "2024-04-30 00:00:00",
+          "end": "2025-04-29 00:00:00",
+          "strategy_return": 13.514,
+          "buy_hold_return": 55.35472705696203,
+          "excess_return": -41.840727056962024,
+          "max_drawdown": 25.82,
+          "transactions": 81
+        },
+        "validation": {
+          "start": "2025-04-30 00:00:00",
+          "end": "2025-07-28 00:00:00",
+          "strategy_return": 16.329,
+          "buy_hold_return": 25.368814509620698,
+          "excess_return": -9.039814509620697,
+          "max_drawdown": 7.53,
+          "transactions": 30
+        },
+        "purge": {
+          "start": "2025-07-29 00:00:00",
+          "end": "2025-08-04 00:00:00",
+          "days": 7
+        },
+        "indicator_warmup_days": 35,
+        "test": {
+          "start": "2025-08-05 00:00:00",
+          "end": "2025-09-03 00:00:00",
+          "strategy_return": 0.0,
+          "buy_hold_return": -2.123933505505793,
+          "excess_return": 2.123933505505793,
+          "max_drawdown": 0.0,
+          "transactions": 0
+        },
+        "frozen_parameters": {
+          "strategy": "MA-BOLL-BANDS",
+          "tol_pct": 0.2,
+          "buy_pct": 0.5,
+          "sell_pct": 0.1,
+          "bollinger_sigma": 5.0,
+          "rsi_period": null,
+          "rsi_oversold": null,
+          "rsi_overbought": null,
+          "kdj_oversold": null,
+          "kdj_overbought": null
+        }
+      },
+      {
+        "fold": 11,
+        "train": {
+          "start": "2024-05-30 00:00:00",
+          "end": "2025-05-29 00:00:00",
+          "strategy_return": 35.79,
+          "buy_hold_return": 54.47900191025392,
+          "excess_return": -18.68900191025392,
+          "max_drawdown": 26.700000000000003,
+          "transactions": 89
+        },
+        "validation": {
+          "start": "2025-05-30 00:00:00",
+          "end": "2025-08-27 00:00:00",
+          "strategy_return": 0.292,
+          "buy_hold_return": 6.997640439799868,
+          "excess_return": -6.705640439799868,
+          "max_drawdown": 6.43,
+          "transactions": 15
+        },
+        "purge": {
+          "start": "2025-08-28 00:00:00",
+          "end": "2025-09-03 00:00:00",
+          "days": 7
+        },
+        "indicator_warmup_days": 35,
+        "test": {
+          "start": "2025-09-04 00:00:00",
+          "end": "2025-10-03 00:00:00",
+          "strategy_return": 0.295,
+          "buy_hold_return": 10.386561579440311,
+          "excess_return": -10.091561579440311,
+          "max_drawdown": 7.449999999999999,
+          "transactions": 6
+        },
+        "frozen_parameters": {
+          "strategy": "MA-BOLL-BANDS",
+          "tol_pct": 0.2,
+          "buy_pct": 0.9,
+          "sell_pct": 0.1,
+          "bollinger_sigma": 5.0,
+          "rsi_period": null,
+          "rsi_oversold": null,
+          "rsi_overbought": null,
+          "kdj_oversold": null,
+          "kdj_overbought": null
+        }
+      },
+      {
+        "fold": 12,
+        "train": {
+          "start": "2024-06-29 00:00:00",
+          "end": "2025-06-28 00:00:00",
+          "strategy_return": 48.505,
+          "buy_hold_return": 75.93479428622774,
+          "excess_return": -27.42979428622774,
+          "max_drawdown": 26.700000000000003,
+          "transactions": 81
+        },
+        "validation": {
+          "start": "2025-06-29 00:00:00",
+          "end": "2025-09-26 00:00:00",
+          "strategy_return": -3.145,
+          "buy_hold_return": 1.1873075399976951,
+          "excess_return": -4.332307539997695,
+          "max_drawdown": 9.6,
+          "transactions": 23
+        },
+        "purge": {
+          "start": "2025-09-27 00:00:00",
+          "end": "2025-10-03 00:00:00",
+          "days": 7
+        },
+        "indicator_warmup_days": 35,
+        "test": {
+          "start": "2025-10-04 00:00:00",
+          "end": "2025-11-02 00:00:00",
+          "strategy_return": -12.359,
+          "buy_hold_return": -9.68234592412841,
+          "excess_return": -2.676654075871589,
+          "max_drawdown": 15.25,
+          "transactions": 6
+        },
+        "frozen_parameters": {
+          "strategy": "MA-BOLL-BANDS",
+          "tol_pct": 0.2,
+          "buy_pct": 0.9,
+          "sell_pct": 0.1,
+          "bollinger_sigma": 5.0,
+          "rsi_period": null,
+          "rsi_oversold": null,
+          "rsi_overbought": null,
+          "kdj_oversold": null,
+          "kdj_overbought": null
+        }
+      },
+      {
+        "fold": 13,
+        "train": {
+          "start": "2024-07-29 00:00:00",
+          "end": "2025-07-28 00:00:00",
+          "strategy_return": 62.841,
+          "buy_hold_return": 76.78051661241521,
+          "excess_return": -13.939516612415211,
+          "max_drawdown": 26.700000000000003,
+          "transactions": 93
+        },
+        "validation": {
+          "start": "2025-07-29 00:00:00",
+          "end": "2025-10-26 00:00:00",
+          "strategy_return": -5.31,
+          "buy_hold_return": -2.8752336992148297,
+          "excess_return": -2.43476630078517,
+          "max_drawdown": 13.669999999999998,
+          "transactions": 12
+        },
+        "purge": {
+          "start": "2025-10-27 00:00:00",
+          "end": "2025-11-02 00:00:00",
+          "days": 7
+        },
+        "indicator_warmup_days": 35,
+        "test": {
+          "start": "2025-11-03 00:00:00",
+          "end": "2025-12-02 00:00:00",
+          "strategy_return": 0.0,
+          "buy_hold_return": -14.359845618965261,
+          "excess_return": 14.359845618965261,
+          "max_drawdown": 0.0,
+          "transactions": 0
+        },
+        "frozen_parameters": {
+          "strategy": "MA-BOLL-BANDS",
+          "tol_pct": 0.2,
+          "buy_pct": 0.9,
+          "sell_pct": 0.1,
+          "bollinger_sigma": 5.0,
+          "rsi_period": null,
+          "rsi_oversold": null,
+          "rsi_overbought": null,
+          "kdj_oversold": null,
+          "kdj_overbought": null
+        }
+      },
+      {
+        "fold": 14,
+        "train": {
+          "start": "2024-08-28 00:00:00",
+          "end": "2025-08-27 00:00:00",
+          "strategy_return": 49.319,
+          "buy_hold_return": 88.46819423764585,
+          "excess_return": -39.149194237645844,
+          "max_drawdown": 25.790000000000003,
+          "transactions": 94
+        },
+        "validation": {
+          "start": "2025-08-28 00:00:00",
+          "end": "2025-11-25 00:00:00",
+          "strategy_return": -22.662,
+          "buy_hold_return": -22.383968999768133,
+          "excess_return": -0.27803100023186644,
+          "max_drawdown": 26.729999999999997,
+          "transactions": 15
+        },
+        "purge": {
+          "start": "2025-11-26 00:00:00",
+          "end": "2025-12-02 00:00:00",
+          "days": 7
+        },
+        "indicator_warmup_days": 35,
+        "test": {
+          "start": "2025-12-03 00:00:00",
+          "end": "2026-01-01 00:00:00",
+          "strategy_return": 0.0,
+          "buy_hold_return": -4.913745538769964,
+          "excess_return": 4.913745538769964,
+          "max_drawdown": 0.0,
+          "transactions": 0
+        },
+        "frozen_parameters": {
+          "strategy": "MA-BOLL-BANDS",
+          "tol_pct": 0.2,
+          "buy_pct": 0.7,
+          "sell_pct": 0.1,
+          "bollinger_sigma": 5.0,
+          "rsi_period": null,
+          "rsi_oversold": null,
+          "rsi_overbought": null,
+          "kdj_oversold": null,
+          "kdj_overbought": null
+        }
+      },
+      {
+        "fold": 15,
+        "train": {
+          "start": "2024-09-27 00:00:00",
+          "end": "2025-09-26 00:00:00",
+          "strategy_return": 32.877,
+          "buy_hold_return": 66.70753132699663,
+          "excess_return": -33.83053132699663,
+          "max_drawdown": 25.790000000000003,
+          "transactions": 94
+        },
+        "validation": {
+          "start": "2025-09-27 00:00:00",
+          "end": "2025-12-25 00:00:00",
+          "strategy_return": -25.387,
+          "buy_hold_return": -20.44092329288276,
+          "excess_return": -4.946076707117239,
+          "max_drawdown": 27.450000000000003,
+          "transactions": 9
+        },
+        "purge": {
+          "start": "2025-12-26 00:00:00",
+          "end": "2026-01-01 00:00:00",
+          "days": 7
+        },
+        "indicator_warmup_days": 35,
+        "test": {
+          "start": "2026-01-02 00:00:00",
+          "end": "2026-01-31 00:00:00",
+          "strategy_return": -16.516,
+          "buy_hold_return": -12.50516555729183,
+          "excess_return": -4.010834442708168,
+          "max_drawdown": 17.91,
+          "transactions": 6
+        },
+        "frozen_parameters": {
+          "strategy": "MA-BOLL-BANDS",
+          "tol_pct": 0.2,
+          "buy_pct": 0.7,
+          "sell_pct": 0.1,
+          "bollinger_sigma": 5.0,
+          "rsi_period": null,
+          "rsi_oversold": null,
+          "rsi_overbought": null,
+          "kdj_oversold": null,
+          "kdj_overbought": null
+        }
+      },
+      {
+        "fold": 16,
+        "train": {
+          "start": "2024-10-27 00:00:00",
+          "end": "2025-10-26 00:00:00",
+          "strategy_return": 9.894,
+          "buy_hold_return": 68.41596137703114,
+          "excess_return": -58.52196137703114,
+          "max_drawdown": 25.1,
+          "transactions": 85
+        },
+        "validation": {
+          "start": "2025-10-27 00:00:00",
+          "end": "2026-01-24 00:00:00",
+          "strategy_return": -7.852,
+          "buy_hold_return": -21.805996355196168,
+          "excess_return": 13.953996355196168,
+          "max_drawdown": 9.99,
+          "transactions": 4
+        },
+        "purge": {
+          "start": "2026-01-25 00:00:00",
+          "end": "2026-01-31 00:00:00",
+          "days": 7
+        },
+        "indicator_warmup_days": 35,
+        "test": {
+          "start": "2026-02-01 00:00:00",
+          "end": "2026-03-02 00:00:00",
+          "strategy_return": 0.0,
+          "buy_hold_return": -10.573391274137734,
+          "excess_return": 10.573391274137734,
+          "max_drawdown": 0.0,
+          "transactions": 0
+        },
+        "frozen_parameters": {
+          "strategy": "MA-BOLL-BANDS",
+          "tol_pct": 0.2,
+          "buy_pct": 0.9,
+          "sell_pct": 0.1,
+          "bollinger_sigma": 3.0,
+          "rsi_period": null,
+          "rsi_oversold": null,
+          "rsi_overbought": null,
+          "kdj_oversold": null,
+          "kdj_overbought": null
+        }
+      },
+      {
+        "fold": 17,
+        "train": {
+          "start": "2024-11-26 00:00:00",
+          "end": "2025-11-25 00:00:00",
+          "strategy_return": 9.589,
+          "buy_hold_return": -4.996674827728231,
+          "excess_return": 14.585674827728232,
+          "max_drawdown": 29.189999999999998,
+          "transactions": 68
+        },
+        "validation": {
+          "start": "2025-11-26 00:00:00",
+          "end": "2026-02-23 00:00:00",
+          "strategy_return": -3.265,
+          "buy_hold_return": -28.544266711403854,
+          "excess_return": 25.279266711403853,
+          "max_drawdown": 11.29,
+          "transactions": 6
+        },
+        "purge": {
+          "start": "2026-02-24 00:00:00",
+          "end": "2026-03-02 00:00:00",
+          "days": 7
+        },
+        "indicator_warmup_days": 35,
+        "test": {
+          "start": "2026-03-03 00:00:00",
+          "end": "2026-04-01 00:00:00",
+          "strategy_return": 2.116,
+          "buy_hold_return": -0.327899558078959,
+          "excess_return": 2.443899558078959,
+          "max_drawdown": 10.25,
+          "transactions": 3
+        },
+        "frozen_parameters": {
+          "strategy": "MA-BOLL-BANDS",
+          "tol_pct": 0.3,
+          "buy_pct": 0.1,
+          "sell_pct": 0.9,
+          "bollinger_sigma": 3.0,
+          "rsi_period": null,
+          "rsi_oversold": null,
+          "rsi_overbought": null,
+          "kdj_oversold": null,
+          "kdj_overbought": null
+        }
+      },
+      {
+        "fold": 18,
+        "train": {
+          "start": "2024-12-26 00:00:00",
+          "end": "2025-12-25 00:00:00",
+          "strategy_return": 13.761,
+          "buy_hold_return": -8.942673470325168,
+          "excess_return": 22.703673470325167,
+          "max_drawdown": 27.089999999999996,
+          "transactions": 67
+        },
+        "validation": {
+          "start": "2025-12-26 00:00:00",
+          "end": "2026-03-25 00:00:00",
+          "strategy_return": 1.703,
+          "buy_hold_return": -18.350819209802594,
+          "excess_return": 20.053819209802594,
+          "max_drawdown": 21.4,
+          "transactions": 12
+        },
+        "purge": {
+          "start": "2026-03-26 00:00:00",
+          "end": "2026-04-01 00:00:00",
+          "days": 7
+        },
+        "indicator_warmup_days": 35,
+        "test": {
+          "start": "2026-04-02 00:00:00",
+          "end": "2026-05-01 00:00:00",
+          "strategy_return": -17.768,
+          "buy_hold_return": 16.933935746903785,
+          "excess_return": -34.701935746903786,
+          "max_drawdown": 27.439999999999998,
+          "transactions": 10
+        },
+        "frozen_parameters": {
+          "strategy": "MA-BOLL-BANDS",
+          "tol_pct": 0.3,
+          "buy_pct": 0.1,
+          "sell_pct": 0.9,
+          "bollinger_sigma": 3.0,
+          "rsi_period": null,
+          "rsi_oversold": null,
+          "rsi_overbought": null,
+          "kdj_oversold": null,
+          "kdj_overbought": null
+        }
+      },
+      {
+        "fold": 19,
+        "train": {
+          "start": "2025-01-25 00:00:00",
+          "end": "2026-01-24 00:00:00",
+          "strategy_return": 2.463,
+          "buy_hold_return": -14.81811624884186,
+          "excess_return": 17.28111624884186,
+          "max_drawdown": 21.959999999999997,
+          "transactions": 73
+        },
+        "validation": {
+          "start": "2026-01-25 00:00:00",
+          "end": "2026-04-24 00:00:00",
+          "strategy_return": -2.611,
+          "buy_hold_return": -10.653272929753598,
+          "excess_return": 8.042272929753597,
+          "max_drawdown": 26.790000000000003,
+          "transactions": 21
+        },
+        "purge": {
+          "start": "2026-04-25 00:00:00",
+          "end": "2026-05-01 00:00:00",
+          "days": 7
+        },
+        "indicator_warmup_days": 35,
+        "test": {
+          "start": "2026-05-02 00:00:00",
+          "end": "2026-05-31 00:00:00",
+          "strategy_return": -3.656,
+          "buy_hold_return": -6.370136814474092,
+          "excess_return": 2.714136814474092,
+          "max_drawdown": 3.75,
+          "transactions": 4
+        },
+        "frozen_parameters": {
+          "strategy": "MA-BOLL-BANDS",
+          "tol_pct": 0.3,
+          "buy_pct": 0.1,
+          "sell_pct": 0.5,
+          "bollinger_sigma": 5.0,
+          "rsi_period": null,
+          "rsi_oversold": null,
+          "rsi_overbought": null,
+          "kdj_oversold": null,
+          "kdj_overbought": null
+        }
+      },
+      {
+        "fold": 20,
+        "train": {
+          "start": "2025-02-24 00:00:00",
+          "end": "2026-02-23 00:00:00",
+          "strategy_return": 8.655,
+          "buy_hold_return": -29.378496886171146,
+          "excess_return": 38.03349688617114,
+          "max_drawdown": 36.75,
+          "transactions": 64
+        },
+        "validation": {
+          "start": "2026-02-24 00:00:00",
+          "end": "2026-05-24 00:00:00",
+          "strategy_return": -1.774,
+          "buy_hold_return": 20.30469190883597,
+          "excess_return": -22.07869190883597,
+          "max_drawdown": 40.96,
+          "transactions": 23
+        },
+        "purge": {
+          "start": "2026-05-25 00:00:00",
+          "end": "2026-05-31 00:00:00",
+          "days": 7
+        },
+        "indicator_warmup_days": 35,
+        "test": {
+          "start": "2026-06-01 00:00:00",
+          "end": "2026-06-30 00:00:00",
+          "strategy_return": 0.0,
+          "buy_hold_return": -17.90279643013686,
+          "excess_return": 17.90279643013686,
+          "max_drawdown": 0.0,
+          "transactions": 0
+        },
+        "frozen_parameters": {
+          "strategy": "MA-BOLL-BANDS",
+          "tol_pct": 0.1,
+          "buy_pct": 0.1,
+          "sell_pct": 0.9,
+          "bollinger_sigma": 2.0,
+          "rsi_period": null,
+          "rsi_oversold": null,
+          "rsi_overbought": null,
+          "kdj_oversold": null,
+          "kdj_overbought": null
+        }
+      },
+      {
+        "fold": 21,
+        "train": {
+          "start": "2025-03-26 00:00:00",
+          "end": "2026-03-25 00:00:00",
+          "strategy_return": 17.128,
+          "buy_hold_return": -17.91829331703433,
+          "excess_return": 35.046293317034326,
+          "max_drawdown": 36.15,
+          "transactions": 76
+        },
+        "validation": {
+          "start": "2026-03-26 00:00:00",
+          "end": "2026-06-23 00:00:00",
+          "strategy_return": -12.952,
+          "buy_hold_return": -8.842941858297348,
+          "excess_return": -4.109058141702652,
+          "max_drawdown": 31.86,
+          "transactions": 26
+        },
+        "purge": {
+          "start": "2026-06-24 00:00:00",
+          "end": "2026-06-30 00:00:00",
+          "days": 7
+        },
+        "indicator_warmup_days": 35,
+        "test": {
+          "start": "2026-07-01 00:00:00",
+          "end": "2026-07-30 00:00:00",
+          "strategy_return": -9.941,
+          "buy_hold_return": 7.923530587764893,
+          "excess_return": -17.864530587764893,
+          "max_drawdown": 10.16,
+          "transactions": 2
+        },
+        "frozen_parameters": {
+          "strategy": "MA-BOLL-BANDS",
+          "tol_pct": 0.1,
+          "buy_pct": 0.1,
+          "sell_pct": 0.9,
+          "bollinger_sigma": 3.0,
+          "rsi_period": null,
+          "rsi_oversold": null,
+          "rsi_overbought": null,
+          "kdj_oversold": null,
+          "kdj_overbought": null
+        }
+      }
+    ],
+    "summary": {
+      "fold_count": 21,
+      "compounded_strategy_return": -44.342086122075216,
+      "compounded_buy_hold_return": -9.597808253285567,
+      "compounded_excess_return": -34.74427786878965,
+      "mean_excess_return": -2.6490493297184656,
+      "excess_win_rate": 0.42857142857142855
+    }
+  }
+]

--- a/artifacts/backtests/btc_walk_forward_pilot.json
+++ b/artifacts/backtests/btc_walk_forward_pilot.json
@@ -1,0 +1,66 @@
+[
+  {
+    "symbol": "BTC",
+    "data_start": "2023-08-04 00:00:00",
+    "data_end": "2026-08-02 00:00:00",
+    "data_rows": 1095,
+    "folds": [
+      {
+        "fold": 1,
+        "train": {
+          "start": "2023-08-04 00:00:00",
+          "end": "2024-08-02 00:00:00",
+          "strategy_return": 85.677,
+          "buy_hold_return": 111.23291585935146,
+          "excess_return": -25.555915859351458,
+          "max_drawdown": 24.88,
+          "transactions": 107
+        },
+        "validation": {
+          "start": "2024-08-03 00:00:00",
+          "end": "2024-10-31 00:00:00",
+          "strategy_return": 7.119,
+          "buy_hold_return": 15.806157666835418,
+          "excess_return": -8.687157666835418,
+          "max_drawdown": 8.4,
+          "transactions": 12
+        },
+        "purge": {
+          "start": "2024-11-01 00:00:00",
+          "end": "2024-11-07 00:00:00",
+          "days": 7
+        },
+        "indicator_warmup_days": 35,
+        "test": {
+          "start": "2024-11-08 00:00:00",
+          "end": "2024-12-07 00:00:00",
+          "strategy_return": 19.716,
+          "buy_hold_return": 30.48265202174154,
+          "excess_return": -10.766652021741539,
+          "max_drawdown": 7.580000000000001,
+          "transactions": 15
+        },
+        "frozen_parameters": {
+          "strategy": "MA-BOLL-BANDS",
+          "tol_pct": 0.2,
+          "buy_pct": 0.9,
+          "sell_pct": 0.1,
+          "bollinger_sigma": 5.0,
+          "rsi_period": null,
+          "rsi_oversold": null,
+          "rsi_overbought": null,
+          "kdj_oversold": null,
+          "kdj_overbought": null
+        }
+      }
+    ],
+    "summary": {
+      "fold_count": 1,
+      "compounded_strategy_return": 19.716,
+      "compounded_buy_hold_return": 30.48265202174154,
+      "compounded_excess_return": -10.766652021741539,
+      "mean_excess_return": -10.766652021741539,
+      "excess_win_rate": 0.0
+    }
+  }
+]

--- a/artifacts/backtests/cross_asset_benchmarks.json
+++ b/artifacts/backtests/cross_asset_benchmarks.json
@@ -1,0 +1,12210 @@
+{
+  "configuration": {
+    "execution_friction_rate": 0.02,
+    "slippage_bps": 10.0,
+    "signal_time": "daily_close",
+    "execution_time": "next_daily_open",
+    "options_enabled": false,
+    "leverage_enabled": false,
+    "parameters_shared_across_assets": true,
+    "regime_parameters": {
+      "trend_ma_days": 200,
+      "trend_slope_days": 20,
+      "range_bollinger_days": 20,
+      "range_bollinger_sigma": 2.0
+    },
+    "fixed_ma_boll_parameters": {
+      "tol_pct": 0.1,
+      "buy_pct": 0.5,
+      "sell_pct": 0.5,
+      "bollinger_sigma": 2.0
+    }
+  },
+  "assets": [
+    {
+      "symbol": "ETH",
+      "data_start": "2023-08-04 00:00:00",
+      "data_end": "2026-08-02 00:00:00",
+      "data_rows": 1095,
+      "folds": [
+        {
+          "fold": 1,
+          "test_start": "2024-11-08 00:00:00",
+          "test_end": "2024-12-07 00:00:00",
+          "market_return": 34.92766101122646,
+          "regime_counts": {
+            "BEAR": 1,
+            "RANGE": 17,
+            "BULL": 12
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -35.12083415760543
+            },
+            "buy_hold": {
+              "return": 35.12083415760543,
+              "max_drawdown": 9.276632093463325,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 32.09701078022174,
+              "max_drawdown": 9.27663209346332,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 0.9666666666666667,
+              "excess_vs_buy_hold": -3.0238233773836924
+            },
+            "dual_ma_50_200": {
+              "return": 3.3597400615346773,
+              "max_drawdown": 0.06626872091366982,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 0.06666666666666667,
+              "excess_vs_buy_hold": -31.761094096070753
+            },
+            "volatility_target": {
+              "return": 23.72648605966534,
+              "max_drawdown": 6.561619628025937,
+              "transactions": 3,
+              "turnover": 0.9152683884255244,
+              "mean_exposure": 0.6957193247740749,
+              "excess_vs_buy_hold": -11.394348097940089
+            },
+            "regime_switch": {
+              "return": 14.581774050684505,
+              "max_drawdown": 4.671549204114817,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 0.4,
+              "excess_vs_buy_hold": -20.539060106920925
+            },
+            "ma_boll_fixed": {
+              "return": 7.077,
+              "max_drawdown": 3.2399999999999998,
+              "transactions": 10,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": -28.04383415760543
+            }
+          }
+        },
+        {
+          "fold": 2,
+          "test_start": "2024-12-08 00:00:00",
+          "test_end": "2025-01-06 00:00:00",
+          "market_return": -7.909294107363618,
+          "regime_counts": {
+            "BULL": 17,
+            "RANGE": 13
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 9.662358201227416
+            },
+            "buy_hold": {
+              "return": -9.662358201227416,
+              "max_drawdown": 18.039284242598306,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": -9.662358201227416,
+              "max_drawdown": 18.039284242598306,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "dual_ma_50_200": {
+              "return": -9.662358201227416,
+              "max_drawdown": 18.039284242598306,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "volatility_target": {
+              "return": -7.388129946898802,
+              "max_drawdown": 15.061738496954039,
+              "transactions": 5,
+              "turnover": 1.1947335194225064,
+              "mean_exposure": 0.7657039876626358,
+              "excess_vs_buy_hold": 2.274228254328614
+            },
+            "regime_switch": {
+              "return": -9.662358201227416,
+              "max_drawdown": 18.039284242598306,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "ma_boll_fixed": {
+              "return": -12.524,
+              "max_drawdown": 15.559999999999999,
+              "transactions": 5,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": -2.861641798772583
+            }
+          }
+        },
+        {
+          "fold": 3,
+          "test_start": "2025-01-07 00:00:00",
+          "test_end": "2025-02-05 00:00:00",
+          "market_return": -17.539356048395437,
+          "regime_counts": {
+            "RANGE": 19,
+            "BULL": 10,
+            "BEAR": 1
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 25.971534594318957
+            },
+            "buy_hold": {
+              "return": -25.971534594318957,
+              "max_drawdown": 21.373606285067787,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": -25.408031121027875,
+              "max_drawdown": 19.119937540843438,
+              "transactions": 2,
+              "turnover": 2.0,
+              "mean_exposure": 0.9,
+              "excess_vs_buy_hold": 0.5635034732910817
+            },
+            "dual_ma_50_200": {
+              "return": -25.971534594318957,
+              "max_drawdown": 21.373606285067787,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "volatility_target": {
+              "return": -22.277807464359146,
+              "max_drawdown": 17.916802488851996,
+              "transactions": 6,
+              "turnover": 1.4597071563717399,
+              "mean_exposure": 0.8061300345570858,
+              "excess_vs_buy_hold": 3.693727129959811
+            },
+            "regime_switch": {
+              "return": -29.007819867525352,
+              "max_drawdown": 23.02318802520707,
+              "transactions": 2,
+              "turnover": 2.0,
+              "mean_exposure": 0.9666666666666667,
+              "excess_vs_buy_hold": -3.0362852732063956
+            },
+            "ma_boll_fixed": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": 25.971534594318957
+            }
+          }
+        },
+        {
+          "fold": 4,
+          "test_start": "2025-02-06 00:00:00",
+          "test_end": "2025-03-07 00:00:00",
+          "market_return": -20.287049995533458,
+          "regime_counts": {
+            "BEAR": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 24.803323637717966
+            },
+            "buy_hold": {
+              "return": -24.803323637717966,
+              "max_drawdown": 24.0483882980044,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 24.803323637717966
+            },
+            "dual_ma_50_200": {
+              "return": -23.77527004368355,
+              "max_drawdown": 23.010013583053453,
+              "transactions": 2,
+              "turnover": 2.0,
+              "mean_exposure": 0.8,
+              "excess_vs_buy_hold": 1.028053594034418
+            },
+            "volatility_target": {
+              "return": -19.132639055152833,
+              "max_drawdown": 19.390810086479686,
+              "transactions": 5,
+              "turnover": 1.4575524808665583,
+              "mean_exposure": 0.7838131116241128,
+              "excess_vs_buy_hold": 5.6706845825651335
+            },
+            "regime_switch": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 24.803323637717966
+            },
+            "ma_boll_fixed": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": 24.803323637717966
+            }
+          }
+        },
+        {
+          "fold": 5,
+          "test_start": "2025-03-08 00:00:00",
+          "test_end": "2025-04-06 00:00:00",
+          "market_return": -28.264006752647962,
+          "regime_counts": {
+            "BEAR": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 27.736402558965125
+            },
+            "buy_hold": {
+              "return": -27.736402558965125,
+              "max_drawdown": 28.26400675264796,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 27.736402558965125
+            },
+            "dual_ma_50_200": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 27.736402558965125
+            },
+            "volatility_target": {
+              "return": -22.1210823100326,
+              "max_drawdown": 22.389493623113534,
+              "transactions": 4,
+              "turnover": 0.9794649706954218,
+              "mean_exposure": 0.6295473268093518,
+              "excess_vs_buy_hold": 5.615320248932523
+            },
+            "regime_switch": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 27.736402558965125
+            },
+            "ma_boll_fixed": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": 27.736402558965125
+            }
+          }
+        },
+        {
+          "fold": 6,
+          "test_start": "2025-04-07 00:00:00",
+          "test_end": "2025-05-06 00:00:00",
+          "market_return": 16.996342656982442,
+          "regime_counts": {
+            "BEAR": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -12.5325707649512
+            },
+            "buy_hold": {
+              "return": 12.5325707649512,
+              "max_drawdown": 8.820552138052491,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -12.5325707649512
+            },
+            "dual_ma_50_200": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -12.5325707649512
+            },
+            "volatility_target": {
+              "return": 6.489846250598408,
+              "max_drawdown": 5.002560936022306,
+              "transactions": 4,
+              "turnover": 1.1038404881457071,
+              "mean_exposure": 0.6224951008376823,
+              "excess_vs_buy_hold": -6.042724514352793
+            },
+            "regime_switch": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -12.5325707649512
+            },
+            "ma_boll_fixed": {
+              "return": -1.063,
+              "max_drawdown": 1.3,
+              "transactions": 3,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": -13.595570764951201
+            }
+          }
+        },
+        {
+          "fold": 7,
+          "test_start": "2025-05-07 00:00:00",
+          "test_end": "2025-06-05 00:00:00",
+          "market_return": 33.28897747790032,
+          "regime_counts": {
+            "BEAR": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -30.06969915060178
+            },
+            "buy_hold": {
+              "return": 30.06969915060178,
+              "max_drawdown": 9.978744033412873,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -30.06969915060178
+            },
+            "dual_ma_50_200": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -30.06969915060178
+            },
+            "volatility_target": {
+              "return": 18.39997268975997,
+              "max_drawdown": 8.794670113230612,
+              "transactions": 4,
+              "turnover": 1.85120815616635,
+              "mean_exposure": 0.6496518845486433,
+              "excess_vs_buy_hold": -11.669726460841812
+            },
+            "regime_switch": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -30.06969915060178
+            },
+            "ma_boll_fixed": {
+              "return": -3.424,
+              "max_drawdown": 5.07,
+              "transactions": 1,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": -33.493699150601785
+            }
+          }
+        },
+        {
+          "fold": 8,
+          "test_start": "2025-06-06 00:00:00",
+          "test_end": "2025-07-05 00:00:00",
+          "market_return": 1.6279633294293383,
+          "regime_counts": {
+            "BEAR": 25,
+            "RANGE": 5
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -2.054588686845249
+            },
+            "buy_hold": {
+              "return": 2.054588686845249,
+              "max_drawdown": 20.90257065757706,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": -11.61376962011702,
+              "max_drawdown": 14.08793893214968,
+              "transactions": 4,
+              "turnover": 4.0,
+              "mean_exposure": 0.16666666666666666,
+              "excess_vs_buy_hold": -13.668358306962269
+            },
+            "dual_ma_50_200": {
+              "return": 2.4369205042050313,
+              "max_drawdown": 3.2111915098890504,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 0.13333333333333333,
+              "excess_vs_buy_hold": 0.3823318173597823
+            },
+            "volatility_target": {
+              "return": 1.4259002103081286,
+              "max_drawdown": 17.512887331826207,
+              "transactions": 4,
+              "turnover": 1.3544172537696575,
+              "mean_exposure": 0.817898674072748,
+              "excess_vs_buy_hold": -0.6286884765371203
+            },
+            "regime_switch": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -2.054588686845249
+            },
+            "ma_boll_fixed": {
+              "return": -6.266,
+              "max_drawdown": 8.55,
+              "transactions": 5,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": -8.320588686845248
+            }
+          }
+        },
+        {
+          "fold": 9,
+          "test_start": "2025-07-06 00:00:00",
+          "test_end": "2025-08-04 00:00:00",
+          "market_return": 44.765887914097306,
+          "regime_counts": {
+            "RANGE": 24,
+            "BULL": 6
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -44.766266073520015
+            },
+            "buy_hold": {
+              "return": 44.766266073520015,
+              "max_drawdown": 12.348854626688354,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 44.766266073520015,
+              "max_drawdown": 12.348854626688354,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "dual_ma_50_200": {
+              "return": 44.766266073520015,
+              "max_drawdown": 12.348854626688354,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "volatility_target": {
+              "return": 38.61133695989154,
+              "max_drawdown": 11.923730360521292,
+              "transactions": 3,
+              "turnover": 1.037025771977834,
+              "mean_exposure": 0.9258912198468019,
+              "excess_vs_buy_hold": -6.1549291136284765
+            },
+            "regime_switch": {
+              "return": -3.9765703234160954,
+              "max_drawdown": 12.416384103008822,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 0.2,
+              "excess_vs_buy_hold": -48.74283639693611
+            },
+            "ma_boll_fixed": {
+              "return": 3.37,
+              "max_drawdown": 4.14,
+              "transactions": 10,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": -41.39626607352002
+            }
+          }
+        },
+        {
+          "fold": 10,
+          "test_start": "2025-08-05 00:00:00",
+          "test_end": "2025-09-03 00:00:00",
+          "market_return": 23.213178294573655,
+          "regime_counts": {
+            "BULL": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -17.095012518004804
+            },
+            "buy_hold": {
+              "return": 17.095012518004804,
+              "max_drawdown": 14.185458909734065,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 17.095012518004804,
+              "max_drawdown": 14.185458909734065,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "dual_ma_50_200": {
+              "return": 17.095012518004804,
+              "max_drawdown": 14.185458909734065,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "volatility_target": {
+              "return": 14.279178802135073,
+              "max_drawdown": 10.40248104854624,
+              "transactions": 4,
+              "turnover": 1.1460032281244772,
+              "mean_exposure": 0.6591177615975964,
+              "excess_vs_buy_hold": -2.815833715869731
+            },
+            "regime_switch": {
+              "return": 17.095012518004804,
+              "max_drawdown": 14.185458909734065,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "ma_boll_fixed": {
+              "return": -1.377,
+              "max_drawdown": 7.779999999999999,
+              "transactions": 4,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": -18.472012518004803
+            }
+          }
+        },
+        {
+          "fold": 11,
+          "test_start": "2025-09-04 00:00:00",
+          "test_end": "2025-10-03 00:00:00",
+          "market_return": 5.010296564321526,
+          "regime_counts": {
+            "BULL": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 0.7249945939429514
+            },
+            "buy_hold": {
+              "return": -0.7249945939429514,
+              "max_drawdown": 17.779532104173025,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": -0.7249945939429514,
+              "max_drawdown": 17.779532104173025,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "dual_ma_50_200": {
+              "return": -0.7249945939429514,
+              "max_drawdown": 17.779532104173025,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "volatility_target": {
+              "return": -1.9048057969928034,
+              "max_drawdown": 18.01255617074549,
+              "transactions": 5,
+              "turnover": 1.3368181513935007,
+              "mean_exposure": 0.866664626428503,
+              "excess_vs_buy_hold": -1.179811203049852
+            },
+            "regime_switch": {
+              "return": -0.7249945939429514,
+              "max_drawdown": 17.779532104173025,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "ma_boll_fixed": {
+              "return": -8.718,
+              "max_drawdown": 11.690000000000001,
+              "transactions": 4,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": -7.993005406057049
+            }
+          }
+        },
+        {
+          "fold": 12,
+          "test_start": "2025-10-04 00:00:00",
+          "test_end": "2025-11-02 00:00:00",
+          "market_return": -12.938502167299948,
+          "regime_counts": {
+            "BULL": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 15.250931196402817
+            },
+            "buy_hold": {
+              "return": -15.250931196402817,
+              "max_drawdown": 20.008923977532078,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": -15.250931196402817,
+              "max_drawdown": 20.008923977532078,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "dual_ma_50_200": {
+              "return": -15.250931196402817,
+              "max_drawdown": 20.008923977532078,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "volatility_target": {
+              "return": -14.728417831401352,
+              "max_drawdown": 18.594538845130575,
+              "transactions": 5,
+              "turnover": 1.784956659005263,
+              "mean_exposure": 0.671455139719849,
+              "excess_vs_buy_hold": 0.5225133650014655
+            },
+            "regime_switch": {
+              "return": -15.250931196402817,
+              "max_drawdown": 20.008923977532078,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "ma_boll_fixed": {
+              "return": -0.067,
+              "max_drawdown": 5.35,
+              "transactions": 1,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": 15.183931196402817
+            }
+          }
+        },
+        {
+          "fold": 13,
+          "test_start": "2025-11-03 00:00:00",
+          "test_end": "2025-12-02 00:00:00",
+          "market_return": -16.86428050157748,
+          "regime_counts": {
+            "BULL": 6,
+            "RANGE": 24
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 24.916029247695292
+            },
+            "buy_hold": {
+              "return": -24.916029247695292,
+              "max_drawdown": 23.252484162682485,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": -35.087592724819416,
+              "max_drawdown": 28.12660772830629,
+              "transactions": 8,
+              "turnover": 8.0,
+              "mean_exposure": 0.20000000000000007,
+              "excess_vs_buy_hold": -10.171563477124124
+            },
+            "dual_ma_50_200": {
+              "return": -26.609549865786764,
+              "max_drawdown": 23.252484162682485,
+              "transactions": 2,
+              "turnover": 2.0,
+              "mean_exposure": 0.9333333333333333,
+              "excess_vs_buy_hold": -1.6935206180914726
+            },
+            "volatility_target": {
+              "return": -22.609542003517213,
+              "max_drawdown": 19.506172408755475,
+              "transactions": 5,
+              "turnover": 1.5556411498812857,
+              "mean_exposure": 0.7660469238210157,
+              "excess_vs_buy_hold": 2.3064872441780793
+            },
+            "regime_switch": {
+              "return": -24.916029247695292,
+              "max_drawdown": 23.252484162682485,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "ma_boll_fixed": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": 24.916029247695292
+            }
+          }
+        },
+        {
+          "fold": 14,
+          "test_start": "2025-12-03 00:00:00",
+          "test_end": "2026-01-01 00:00:00",
+          "market_return": -5.776323878106615,
+          "regime_counts": {
+            "RANGE": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 1.8325661628388112
+            },
+            "buy_hold": {
+              "return": -1.8325661628388112,
+              "max_drawdown": 14.90821686210569,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 1.8325661628388112
+            },
+            "dual_ma_50_200": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 1.8325661628388112
+            },
+            "volatility_target": {
+              "return": -1.5418534514030635,
+              "max_drawdown": 11.444274803945621,
+              "transactions": 2,
+              "turnover": 0.9595818630379868,
+              "mean_exposure": 0.8125297658853602,
+              "excess_vs_buy_hold": 0.29071271143574773
+            },
+            "regime_switch": {
+              "return": 6.148344053787391,
+              "max_drawdown": 5.224629590134111,
+              "transactions": 2,
+              "turnover": 2.0,
+              "mean_exposure": 0.23333333333333334,
+              "excess_vs_buy_hold": 7.980910216626203
+            },
+            "ma_boll_fixed": {
+              "return": -7.455,
+              "max_drawdown": 8.75,
+              "transactions": 2,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": -5.622433837161189
+            }
+          }
+        },
+        {
+          "fold": 15,
+          "test_start": "2026-01-02 00:00:00",
+          "test_end": "2026-01-31 00:00:00",
+          "market_return": -21.548896958837926,
+          "regime_counts": {
+            "RANGE": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 20.094584912722247
+            },
+            "buy_hold": {
+              "return": -20.094584912722247,
+              "max_drawdown": 26.91479975677514,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 20.094584912722247
+            },
+            "dual_ma_50_200": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 20.094584912722247
+            },
+            "volatility_target": {
+              "return": -18.362958394967098,
+              "max_drawdown": 25.330973796314503,
+              "transactions": 2,
+              "turnover": 1.1246590725205678,
+              "mean_exposure": 0.9541089454318067,
+              "excess_vs_buy_hold": 1.7316265177551493
+            },
+            "regime_switch": {
+              "return": -18.3466505602103,
+              "max_drawdown": 18.991201842227856,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 0.36666666666666664,
+              "excess_vs_buy_hold": 1.7479343525119475
+            },
+            "ma_boll_fixed": {
+              "return": -18.974,
+              "max_drawdown": 19.97,
+              "transactions": 6,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": 1.1205849127222471
+            }
+          }
+        },
+        {
+          "fold": 16,
+          "test_start": "2026-02-01 00:00:00",
+          "test_end": "2026-03-02 00:00:00",
+          "market_return": -10.695328502521873,
+          "regime_counts": {
+            "RANGE": 4,
+            "BEAR": 26
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 19.051771569757182
+            },
+            "buy_hold": {
+              "return": -19.051771569757182,
+              "max_drawdown": 22.16385032935383,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 19.051771569757182
+            },
+            "dual_ma_50_200": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 19.051771569757182
+            },
+            "volatility_target": {
+              "return": -13.602915044375962,
+              "max_drawdown": 14.661333030465022,
+              "transactions": 4,
+              "turnover": 1.1367787542619303,
+              "mean_exposure": 0.5257189250771902,
+              "excess_vs_buy_hold": 5.4488565253812205
+            },
+            "regime_switch": {
+              "return": -16.02403531720079,
+              "max_drawdown": 10.389356929212381,
+              "transactions": 2,
+              "turnover": 2.0,
+              "mean_exposure": 0.13333333333333341,
+              "excess_vs_buy_hold": 3.027736252556391
+            },
+            "ma_boll_fixed": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": 19.051771569757182
+            }
+          }
+        },
+        {
+          "fold": 17,
+          "test_start": "2026-03-03 00:00:00",
+          "test_end": "2026-04-01 00:00:00",
+          "market_return": 7.945834173895494,
+          "regime_counts": {
+            "BEAR": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -3.359453887732333
+            },
+            "buy_hold": {
+              "return": 3.359453887732333,
+              "max_drawdown": 15.653833240542792,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -3.359453887732333
+            },
+            "dual_ma_50_200": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -3.359453887732333
+            },
+            "volatility_target": {
+              "return": 1.9041485872397956,
+              "max_drawdown": 12.536122104242292,
+              "transactions": 2,
+              "turnover": 0.8319891764848865,
+              "mean_exposure": 0.729972602249028,
+              "excess_vs_buy_hold": -1.4553053004925376
+            },
+            "regime_switch": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -3.359453887732333
+            },
+            "ma_boll_fixed": {
+              "return": -0.825,
+              "max_drawdown": 9.28,
+              "transactions": 4,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": -4.184453887732333
+            }
+          }
+        },
+        {
+          "fold": 18,
+          "test_start": "2026-04-02 00:00:00",
+          "test_end": "2026-05-01 00:00:00",
+          "market_return": 11.59165261013917,
+          "regime_counts": {
+            "BEAR": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -5.0047856691630255
+            },
+            "buy_hold": {
+              "return": 5.0047856691630255,
+              "max_drawdown": 6.866473749483258,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -5.0047856691630255
+            },
+            "dual_ma_50_200": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -5.0047856691630255
+            },
+            "volatility_target": {
+              "return": 5.042719196868761,
+              "max_drawdown": 6.079005023986259,
+              "transactions": 4,
+              "turnover": 1.281196799187255,
+              "mean_exposure": 0.8694664602631235,
+              "excess_vs_buy_hold": 0.03793352770573577
+            },
+            "regime_switch": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -5.0047856691630255
+            },
+            "ma_boll_fixed": {
+              "return": -1.426,
+              "max_drawdown": 5.46,
+              "transactions": 5,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": -6.430785669163026
+            }
+          }
+        },
+        {
+          "fold": 19,
+          "test_start": "2026-05-02 00:00:00",
+          "test_end": "2026-05-31 00:00:00",
+          "market_return": -13.377816717523306,
+          "regime_counts": {
+            "BEAR": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 14.406725164556333
+            },
+            "buy_hold": {
+              "return": -14.406725164556333,
+              "max_drawdown": 15.361388622974184,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 14.406725164556333
+            },
+            "dual_ma_50_200": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 14.406725164556333
+            },
+            "volatility_target": {
+              "return": -13.697783264565789,
+              "max_drawdown": 14.61348925583744,
+              "transactions": 1,
+              "turnover": 0.9507909055046943,
+              "mean_exposure": 0.947377040427198,
+              "excess_vs_buy_hold": 0.7089418999905437
+            },
+            "regime_switch": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 14.406725164556333
+            },
+            "ma_boll_fixed": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": 14.406725164556333
+            }
+          }
+        },
+        {
+          "fold": 20,
+          "test_start": "2026-06-01 00:00:00",
+          "test_end": "2026-06-30 00:00:00",
+          "market_return": -21.663103656196903,
+          "regime_counts": {
+            "BEAR": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 23.317616703831078
+            },
+            "buy_hold": {
+              "return": -23.317616703831078,
+              "max_drawdown": 21.870904406671553,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 23.317616703831078
+            },
+            "dual_ma_50_200": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 23.317616703831078
+            },
+            "volatility_target": {
+              "return": -22.591674700305255,
+              "max_drawdown": 21.77871462528591,
+              "transactions": 3,
+              "turnover": 1.4479006282657234,
+              "mean_exposure": 0.8428974715897678,
+              "excess_vs_buy_hold": 0.725942003525823
+            },
+            "regime_switch": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 23.317616703831078
+            },
+            "ma_boll_fixed": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": 23.317616703831078
+            }
+          }
+        },
+        {
+          "fold": 21,
+          "test_start": "2026-07-01 00:00:00",
+          "test_end": "2026-07-30 00:00:00",
+          "market_return": 19.18078007927535,
+          "regime_counts": {
+            "BEAR": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -19.4698304240289
+            },
+            "buy_hold": {
+              "return": 19.4698304240289,
+              "max_drawdown": 3.959100247150461,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -19.4698304240289
+            },
+            "dual_ma_50_200": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -19.4698304240289
+            },
+            "volatility_target": {
+              "return": 19.4698304240289,
+              "max_drawdown": 3.959100247150461,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "regime_switch": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -19.4698304240289
+            },
+            "ma_boll_fixed": {
+              "return": 2.085,
+              "max_drawdown": 3.34,
+              "transactions": 6,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": -17.384830424028898
+            }
+          }
+        }
+      ],
+      "summary": {
+        "cash": {
+          "continuous_oos_return": 0.0,
+          "continuous_excess_vs_buy_hold": 35.13779337151707,
+          "fold_compounded_return": 0.0,
+          "mean_fold_return": 0.0,
+          "median_fold_return": 0.0,
+          "mean_excess_vs_buy_hold": 1.8236093910249256,
+          "excess_win_rate": 0.5714285714285714,
+          "continuous_transactions": 0,
+          "continuous_turnover": 0.0,
+          "continuous_max_drawdown": 0.0,
+          "mean_fold_max_drawdown": 0.0
+        },
+        "buy_hold": {
+          "continuous_oos_return": -35.13779337151707,
+          "continuous_excess_vs_buy_hold": 0.0,
+          "fold_compounded_return": -57.55499426762616,
+          "mean_fold_return": -1.8236093910249256,
+          "median_fold_return": -1.8325661628388112,
+          "mean_excess_vs_buy_hold": 0.0,
+          "excess_win_rate": 0.0,
+          "continuous_transactions": 1,
+          "continuous_turnover": 1.0,
+          "continuous_max_drawdown": 67.55345017766712,
+          "mean_fold_max_drawdown": 16.951314547461482
+        },
+        "sma200_trend": {
+          "continuous_oos_return": -17.283041469712934,
+          "continuous_excess_vs_buy_hold": 17.854751901804136,
+          "fold_compounded_return": -27.163886850455356,
+          "mean_fold_return": -0.18044705170433048,
+          "median_fold_return": 0.0,
+          "mean_excess_vs_buy_hold": 1.6431623393205952,
+          "excess_win_rate": 0.38095238095238093,
+          "continuous_transactions": 14,
+          "continuous_turnover": 14.0,
+          "continuous_max_drawdown": 46.395750212538736,
+          "mean_fold_max_drawdown": 7.284436674070884
+        },
+        "dual_ma_50_200": {
+          "continuous_oos_return": -33.06442263806355,
+          "continuous_excess_vs_buy_hold": 2.0733707334535225,
+          "fold_compounded_return": -43.50740962078521,
+          "mean_fold_return": -1.635080920861806,
+          "median_fold_return": 0.0,
+          "mean_excess_vs_buy_hold": 0.18852847016311958,
+          "excess_win_rate": 0.38095238095238093,
+          "continuous_transactions": 4,
+          "continuous_turnover": 4.0,
+          "continuous_max_drawdown": 45.784275114568636,
+          "mean_fold_max_drawdown": 7.298838958206299
+        },
+        "volatility_target": {
+          "continuous_oos_return": -36.00246814439912,
+          "continuous_excess_vs_buy_hold": -0.8646747728820472,
+          "fold_compounded_return": -56.3639677611032,
+          "mean_fold_return": -2.4100090515940953,
+          "median_fold_return": -1.9048057969928034,
+          "mean_excess_vs_buy_hold": -0.5863996605691697,
+          "excess_win_rate": 0.5714285714285714,
+          "continuous_transactions": 61,
+          "continuous_turnover": 10.338275060415254,
+          "continuous_max_drawdown": 62.472042707157016,
+          "mean_fold_max_drawdown": 14.355860686925281
+        },
+        "regime_switch": {
+          "continuous_oos_return": -54.98675716247552,
+          "continuous_excess_vs_buy_hold": -19.84896379095845,
+          "fold_compounded_return": -62.009524324417775,
+          "mean_fold_return": -3.813536127864015,
+          "median_fold_return": 0.0,
+          "mean_excess_vs_buy_hold": -1.9899267368390894,
+          "excess_win_rate": 0.3333333333333333,
+          "continuous_transactions": 6,
+          "continuous_turnover": 6.0,
+          "continuous_max_drawdown": 60.79298217797117,
+          "mean_fold_max_drawdown": 7.999142528125001
+        },
+        "ma_boll_fixed": {
+          "continuous_oos_return": -34.119,
+          "continuous_excess_vs_buy_hold": 1.01879337151707,
+          "fold_compounded_return": -41.6177414670991,
+          "mean_fold_return": -2.361285714285714,
+          "median_fold_return": -0.067,
+          "mean_excess_vs_buy_hold": -0.5376763232607888,
+          "excess_win_rate": 0.42857142857142855,
+          "continuous_transactions": 121,
+          "continuous_turnover": null,
+          "continuous_max_drawdown": 43.87,
+          "mean_fold_max_drawdown": 5.213333333333333
+        }
+      }
+    },
+    {
+      "symbol": "BTC",
+      "data_start": "2023-08-04 00:00:00",
+      "data_end": "2026-08-02 00:00:00",
+      "data_rows": 1095,
+      "folds": [
+        {
+          "fold": 1,
+          "test_start": "2024-11-08 00:00:00",
+          "test_end": "2024-12-07 00:00:00",
+          "market_return": 30.48265202174154,
+          "regime_counts": {
+            "BULL": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -28.843041359854094
+            },
+            "buy_hold": {
+              "return": 28.843041359854094,
+              "max_drawdown": 7.004449298224314,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 28.843041359854094,
+              "max_drawdown": 7.004449298224314,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "dual_ma_50_200": {
+              "return": 28.843041359854094,
+              "max_drawdown": 7.004449298224314,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "volatility_target": {
+              "return": 25.316592078950116,
+              "max_drawdown": 5.629492985896433,
+              "transactions": 3,
+              "turnover": 1.4167726043300226,
+              "mean_exposure": 0.8632722938082115,
+              "excess_vs_buy_hold": -3.5264492809039787
+            },
+            "regime_switch": {
+              "return": 28.843041359854094,
+              "max_drawdown": 7.004449298224314,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "ma_boll_fixed": {
+              "return": 5.368,
+              "max_drawdown": 1.6400000000000001,
+              "transactions": 10,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": -23.475041359854096
+            }
+          }
+        },
+        {
+          "fold": 2,
+          "test_start": "2024-12-08 00:00:00",
+          "test_end": "2025-01-06 00:00:00",
+          "market_return": 1.1136530174833181,
+          "regime_counts": {
+            "BULL": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -0.2592427565525135
+            },
+            "buy_hold": {
+              "return": 0.2592427565525135,
+              "max_drawdown": 12.570639647674732,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 0.2592427565525135,
+              "max_drawdown": 12.570639647674732,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "dual_ma_50_200": {
+              "return": 0.2592427565525135,
+              "max_drawdown": 12.570639647674732,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "volatility_target": {
+              "return": 0.2592427565525135,
+              "max_drawdown": 12.570639647674732,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "regime_switch": {
+              "return": 0.2592427565525135,
+              "max_drawdown": 12.570639647674732,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "ma_boll_fixed": {
+              "return": -0.842,
+              "max_drawdown": 3.6799999999999997,
+              "transactions": 3,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": -1.1012427565525136
+            }
+          }
+        },
+        {
+          "fold": 3,
+          "test_start": "2025-01-07 00:00:00",
+          "test_end": "2025-02-05 00:00:00",
+          "market_return": -0.3529280350877628,
+          "regime_counts": {
+            "BULL": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 7.482720496386975
+            },
+            "buy_hold": {
+              "return": -7.482720496386975,
+              "max_drawdown": 8.979693777744222,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": -7.482720496386975,
+              "max_drawdown": 8.979693777744222,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "dual_ma_50_200": {
+              "return": -7.482720496386975,
+              "max_drawdown": 8.979693777744222,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "volatility_target": {
+              "return": -7.482720496386975,
+              "max_drawdown": 8.979693777744222,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "regime_switch": {
+              "return": -7.482720496386975,
+              "max_drawdown": 8.979693777744222,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "ma_boll_fixed": {
+              "return": -6.681,
+              "max_drawdown": 8.19,
+              "transactions": 5,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": 0.8017204963869746
+            }
+          }
+        },
+        {
+          "fold": 4,
+          "test_start": "2025-02-06 00:00:00",
+          "test_end": "2025-03-07 00:00:00",
+          "market_return": -10.100632441728418,
+          "regime_counts": {
+            "BULL": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 12.039552809416387
+            },
+            "buy_hold": {
+              "return": -12.039552809416387,
+              "max_drawdown": 14.29724835969686,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": -12.039552809416387,
+              "max_drawdown": 14.29724835969686,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "dual_ma_50_200": {
+              "return": -12.039552809416387,
+              "max_drawdown": 14.29724835969686,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "volatility_target": {
+              "return": -11.695180651655324,
+              "max_drawdown": 14.29724835969686,
+              "transactions": 3,
+              "turnover": 1.2394286418185754,
+              "mean_exposure": 0.9639498122508122,
+              "excess_vs_buy_hold": 0.3443721577610628
+            },
+            "regime_switch": {
+              "return": -12.039552809416387,
+              "max_drawdown": 14.29724835969686,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "ma_boll_fixed": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": 12.039552809416387
+            }
+          }
+        },
+        {
+          "fold": 5,
+          "test_start": "2025-03-08 00:00:00",
+          "test_end": "2025-04-06 00:00:00",
+          "market_return": -9.037611434145044,
+          "regime_counts": {
+            "BULL": 11,
+            "RANGE": 19
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 11.540234810252203
+            },
+            "buy_hold": {
+              "return": -11.540234810252203,
+              "max_drawdown": 10.363829365097505,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": -31.794188222836684,
+              "max_drawdown": 29.86457131085694,
+              "transactions": 10,
+              "turnover": 10.0,
+              "mean_exposure": 0.36666666666666664,
+              "excess_vs_buy_hold": -20.25395341258448
+            },
+            "dual_ma_50_200": {
+              "return": -11.540234810252203,
+              "max_drawdown": 10.363829365097505,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "volatility_target": {
+              "return": -10.86357877791725,
+              "max_drawdown": 9.942940109475058,
+              "transactions": 3,
+              "turnover": 1.011053581215512,
+              "mean_exposure": 0.8198713544134333,
+              "excess_vs_buy_hold": 0.6766560323349537
+            },
+            "regime_switch": {
+              "return": -11.540234810252203,
+              "max_drawdown": 10.363829365097505,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "ma_boll_fixed": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": 11.540234810252203
+            }
+          }
+        },
+        {
+          "fold": 6,
+          "test_start": "2025-04-07 00:00:00",
+          "test_end": "2025-05-06 00:00:00",
+          "market_return": 22.32195145120386,
+          "regime_counts": {
+            "RANGE": 16,
+            "BULL": 14
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -20.87535007387107
+            },
+            "buy_hold": {
+              "return": 20.87535007387107,
+              "max_drawdown": 3.640878763017261,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 1.4549481592327718,
+              "max_drawdown": 2.693360542998791,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 0.4666666666666667,
+              "excess_vs_buy_hold": -19.420401914638298
+            },
+            "dual_ma_50_200": {
+              "return": -3.2558066435616984,
+              "max_drawdown": 2.097999999999997,
+              "transactions": 2,
+              "turnover": 2.0,
+              "mean_exposure": 0.03333333333333333,
+              "excess_vs_buy_hold": -24.131156717432766
+            },
+            "volatility_target": {
+              "return": 18.060402434490342,
+              "max_drawdown": 3.640878763017261,
+              "transactions": 3,
+              "turnover": 1.2255286959864584,
+              "mean_exposure": 0.930787482793629,
+              "excess_vs_buy_hold": -2.8149476393807262
+            },
+            "regime_switch": {
+              "return": 20.87535007387107,
+              "max_drawdown": 3.640878763017261,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "ma_boll_fixed": {
+              "return": -0.612,
+              "max_drawdown": 2.75,
+              "transactions": 4,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": -21.487350073871067
+            }
+          }
+        },
+        {
+          "fold": 7,
+          "test_start": "2025-05-07 00:00:00",
+          "test_end": "2025-06-05 00:00:00",
+          "market_return": 4.615229232045581,
+          "regime_counts": {
+            "BULL": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -2.628319337281737
+            },
+            "buy_hold": {
+              "return": 2.628319337281737,
+              "max_drawdown": 9.120748143558334,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 2.628319337281737,
+              "max_drawdown": 9.120748143558334,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "dual_ma_50_200": {
+              "return": -11.027313840408137,
+              "max_drawdown": 11.027313840408134,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 0.4666666666666667,
+              "excess_vs_buy_hold": -13.655633177689875
+            },
+            "volatility_target": {
+              "return": 2.628319337281737,
+              "max_drawdown": 9.120748143558334,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "regime_switch": {
+              "return": 2.628319337281737,
+              "max_drawdown": 9.120748143558334,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "ma_boll_fixed": {
+              "return": -5.716,
+              "max_drawdown": 6.79,
+              "transactions": 7,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": -8.344319337281737
+            }
+          }
+        },
+        {
+          "fold": 8,
+          "test_start": "2025-06-06 00:00:00",
+          "test_end": "2025-07-05 00:00:00",
+          "market_return": 3.7489102339626434,
+          "regime_counts": {
+            "BULL": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -4.3538532224476345
+            },
+            "buy_hold": {
+              "return": 4.3538532224476345,
+              "max_drawdown": 8.443048290722812,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 4.3538532224476345,
+              "max_drawdown": 8.443048290722812,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "dual_ma_50_200": {
+              "return": 4.3538532224476345,
+              "max_drawdown": 8.443048290722812,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "volatility_target": {
+              "return": 4.3538532224476345,
+              "max_drawdown": 8.443048290722812,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "regime_switch": {
+              "return": 4.3538532224476345,
+              "max_drawdown": 8.443048290722812,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "ma_boll_fixed": {
+              "return": -1.342,
+              "max_drawdown": 1.44,
+              "transactions": 1,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": -5.695853222447635
+            }
+          }
+        },
+        {
+          "fold": 9,
+          "test_start": "2025-07-06 00:00:00",
+          "test_end": "2025-08-04 00:00:00",
+          "market_return": 5.358044185991995,
+          "regime_counts": {
+            "BULL": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -4.106511381055533
+            },
+            "buy_hold": {
+              "return": 4.106511381055533,
+              "max_drawdown": 6.175737417595785,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 4.106511381055533,
+              "max_drawdown": 6.175737417595785,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "dual_ma_50_200": {
+              "return": 4.106511381055533,
+              "max_drawdown": 6.175737417595785,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "volatility_target": {
+              "return": 4.106511381055533,
+              "max_drawdown": 6.175737417595785,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "regime_switch": {
+              "return": 4.106511381055533,
+              "max_drawdown": 6.175737417595785,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "ma_boll_fixed": {
+              "return": -4.275,
+              "max_drawdown": 5.96,
+              "transactions": 4,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": -8.381511381055534
+            }
+          }
+        },
+        {
+          "fold": 10,
+          "test_start": "2025-08-05 00:00:00",
+          "test_end": "2025-09-03 00:00:00",
+          "market_return": -2.123933505505793,
+          "regime_counts": {
+            "BULL": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 4.947890095345175
+            },
+            "buy_hold": {
+              "return": -4.947890095345175,
+              "max_drawdown": 12.213539877847396,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": -4.947890095345175,
+              "max_drawdown": 12.213539877847396,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "dual_ma_50_200": {
+              "return": -4.947890095345175,
+              "max_drawdown": 12.213539877847396,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "volatility_target": {
+              "return": -4.947890095345175,
+              "max_drawdown": 12.213539877847396,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "regime_switch": {
+              "return": -4.947890095345175,
+              "max_drawdown": 12.213539877847396,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "ma_boll_fixed": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": 4.947890095345175
+            }
+          }
+        },
+        {
+          "fold": 11,
+          "test_start": "2025-09-04 00:00:00",
+          "test_end": "2025-10-03 00:00:00",
+          "market_return": 10.386561579440311,
+          "regime_counts": {
+            "BULL": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -7.127631698441506
+            },
+            "buy_hold": {
+              "return": 7.127631698441506,
+              "max_drawdown": 6.900825489758441,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 7.127631698441506,
+              "max_drawdown": 6.900825489758441,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "dual_ma_50_200": {
+              "return": 7.127631698441506,
+              "max_drawdown": 6.900825489758441,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "volatility_target": {
+              "return": 7.127631698441506,
+              "max_drawdown": 6.900825489758441,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "regime_switch": {
+              "return": 7.127631698441506,
+              "max_drawdown": 6.900825489758441,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "ma_boll_fixed": {
+              "return": -0.576,
+              "max_drawdown": 1.9800000000000002,
+              "transactions": 3,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": -7.703631698441505
+            }
+          }
+        },
+        {
+          "fold": 12,
+          "test_start": "2025-10-04 00:00:00",
+          "test_end": "2025-11-02 00:00:00",
+          "market_return": -9.68234592412841,
+          "regime_counts": {
+            "BULL": 26,
+            "RANGE": 4
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 11.462253071228313
+            },
+            "buy_hold": {
+              "return": -11.462253071228313,
+              "max_drawdown": 14.62142906534924,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": -26.242413305800138,
+              "max_drawdown": 26.42402591480461,
+              "transactions": 7,
+              "turnover": 7.0,
+              "mean_exposure": 0.8666666666666667,
+              "excess_vs_buy_hold": -14.780160234571825
+            },
+            "dual_ma_50_200": {
+              "return": -11.462253071228313,
+              "max_drawdown": 14.62142906534924,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "volatility_target": {
+              "return": -11.462253071228313,
+              "max_drawdown": 14.62142906534924,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "regime_switch": {
+              "return": -11.462253071228313,
+              "max_drawdown": 14.62142906534924,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "ma_boll_fixed": {
+              "return": -7.749,
+              "max_drawdown": 9.520000000000001,
+              "transactions": 4,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": 3.713253071228313
+            }
+          }
+        },
+        {
+          "fold": 13,
+          "test_start": "2025-11-03 00:00:00",
+          "test_end": "2025-12-02 00:00:00",
+          "market_return": -14.359845618965261,
+          "regime_counts": {
+            "BULL": 1,
+            "RANGE": 23,
+            "BEAR": 6
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 19.158312255369992
+            },
+            "buy_hold": {
+              "return": -19.158312255369992,
+              "max_drawdown": 20.494161172359128,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": -7.583496160769176,
+              "max_drawdown": 2.0979908144860526,
+              "transactions": 2,
+              "turnover": 2.0,
+              "mean_exposure": 0.03333333333333333,
+              "excess_vs_buy_hold": 11.574816094600816
+            },
+            "dual_ma_50_200": {
+              "return": -18.26736375233715,
+              "max_drawdown": 13.416013674408262,
+              "transactions": 2,
+              "turnover": 2.0,
+              "mean_exposure": 0.46666666666666673,
+              "excess_vs_buy_hold": 0.8909485030328419
+            },
+            "volatility_target": {
+              "return": -19.158312255369992,
+              "max_drawdown": 20.494161172359128,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "regime_switch": {
+              "return": -21.542723185778602,
+              "max_drawdown": 20.494161172359128,
+              "transactions": 2,
+              "turnover": 2.0,
+              "mean_exposure": 0.8,
+              "excess_vs_buy_hold": -2.3844109304086096
+            },
+            "ma_boll_fixed": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": 19.158312255369992
+            }
+          }
+        },
+        {
+          "fold": 14,
+          "test_start": "2025-12-03 00:00:00",
+          "test_end": "2026-01-01 00:00:00",
+          "market_return": -4.913745538769964,
+          "regime_counts": {
+            "BEAR": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 4.713733583553969
+            },
+            "buy_hold": {
+              "return": -4.713733583553969,
+              "max_drawdown": 8.470024868899092,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 4.713733583553969
+            },
+            "dual_ma_50_200": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 4.713733583553969
+            },
+            "volatility_target": {
+              "return": -4.572018108552878,
+              "max_drawdown": 8.215897308489053,
+              "transactions": 1,
+              "turnover": 0.9699356205672018,
+              "mean_exposure": 0.9685199765063295,
+              "excess_vs_buy_hold": 0.14171547500109138
+            },
+            "regime_switch": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 4.713733583553969
+            },
+            "ma_boll_fixed": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": 4.713733583553969
+            }
+          }
+        },
+        {
+          "fold": 15,
+          "test_start": "2026-01-02 00:00:00",
+          "test_end": "2026-01-31 00:00:00",
+          "market_return": -12.50516555729183,
+          "regime_counts": {
+            "BEAR": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 13.226020515776549
+            },
+            "buy_hold": {
+              "return": -13.226020515776549,
+              "max_drawdown": 18.78324461912922,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 13.226020515776549
+            },
+            "dual_ma_50_200": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 13.226020515776549
+            },
+            "volatility_target": {
+              "return": -13.226020515776549,
+              "max_drawdown": 18.78324461912922,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "regime_switch": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 13.226020515776549
+            },
+            "ma_boll_fixed": {
+              "return": -13.747,
+              "max_drawdown": 15.17,
+              "transactions": 5,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": -0.5209794842234512
+            }
+          }
+        },
+        {
+          "fold": 16,
+          "test_start": "2026-02-01 00:00:00",
+          "test_end": "2026-03-02 00:00:00",
+          "market_return": -10.573391274137734,
+          "regime_counts": {
+            "BEAR": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 14.420712020440751
+            },
+            "buy_hold": {
+              "return": -14.420712020440751,
+              "max_drawdown": 20.10290758244271,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 14.420712020440751
+            },
+            "dual_ma_50_200": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 14.420712020440751
+            },
+            "volatility_target": {
+              "return": -17.028698034186252,
+              "max_drawdown": 20.10290758244271,
+              "transactions": 5,
+              "turnover": 1.9362778569925434,
+              "mean_exposure": 0.6931432866179676,
+              "excess_vs_buy_hold": -2.607986013745501
+            },
+            "regime_switch": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 14.420712020440751
+            },
+            "ma_boll_fixed": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": 14.420712020440751
+            }
+          }
+        },
+        {
+          "fold": 17,
+          "test_start": "2026-03-03 00:00:00",
+          "test_end": "2026-04-01 00:00:00",
+          "market_return": -0.327899558078959,
+          "regime_counts": {
+            "BEAR": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 3.1165211197597964
+            },
+            "buy_hold": {
+              "return": -3.1165211197597964,
+              "max_drawdown": 11.84987528154961,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 3.1165211197597964
+            },
+            "dual_ma_50_200": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 3.1165211197597964
+            },
+            "volatility_target": {
+              "return": -4.461746447720594,
+              "max_drawdown": 11.92932621075309,
+              "transactions": 3,
+              "turnover": 1.2365028617683766,
+              "mean_exposure": 0.9690351581994865,
+              "excess_vs_buy_hold": -1.3452253279607973
+            },
+            "regime_switch": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 3.1165211197597964
+            },
+            "ma_boll_fixed": {
+              "return": -2.783,
+              "max_drawdown": 3.82,
+              "transactions": 2,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": 0.3335211197597965
+            }
+          }
+        },
+        {
+          "fold": 18,
+          "test_start": "2026-04-02 00:00:00",
+          "test_end": "2026-05-01 00:00:00",
+          "market_return": 16.933935746903785,
+          "regime_counts": {
+            "BEAR": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -12.443855062984909
+            },
+            "buy_hold": {
+              "return": 12.443855062984909,
+              "max_drawdown": 4.243058438862368,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -12.443855062984909
+            },
+            "dual_ma_50_200": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -12.443855062984909
+            },
+            "volatility_target": {
+              "return": 12.443855062984909,
+              "max_drawdown": 4.243058438862368,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "regime_switch": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -12.443855062984909
+            },
+            "ma_boll_fixed": {
+              "return": 0.68,
+              "max_drawdown": 1.31,
+              "transactions": 7,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": -11.76385506298491
+            }
+          }
+        },
+        {
+          "fold": 19,
+          "test_start": "2026-05-02 00:00:00",
+          "test_end": "2026-05-31 00:00:00",
+          "market_return": -6.370136814474092,
+          "regime_counts": {
+            "BEAR": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 7.800419824469573
+            },
+            "buy_hold": {
+              "return": -7.800419824469573,
+              "max_drawdown": 10.642601326090606,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 7.800419824469573
+            },
+            "dual_ma_50_200": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 7.800419824469573
+            },
+            "volatility_target": {
+              "return": -7.800419824469573,
+              "max_drawdown": 10.642601326090606,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "regime_switch": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 7.800419824469573
+            },
+            "ma_boll_fixed": {
+              "return": -5.148,
+              "max_drawdown": 5.25,
+              "transactions": 3,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": 2.6524198244695736
+            }
+          }
+        },
+        {
+          "fold": 20,
+          "test_start": "2026-06-01 00:00:00",
+          "test_end": "2026-06-30 00:00:00",
+          "market_return": -17.90279643013686,
+          "regime_counts": {
+            "BEAR": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 22.096645823574523
+            },
+            "buy_hold": {
+              "return": -22.096645823574523,
+              "max_drawdown": 17.902796430136856,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 22.096645823574523
+            },
+            "dual_ma_50_200": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 22.096645823574523
+            },
+            "volatility_target": {
+              "return": -22.096645823574523,
+              "max_drawdown": 17.902796430136856,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "regime_switch": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 22.096645823574523
+            },
+            "ma_boll_fixed": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": 22.096645823574523
+            }
+          }
+        },
+        {
+          "fold": 21,
+          "test_start": "2026-07-01 00:00:00",
+          "test_end": "2026-07-30 00:00:00",
+          "market_return": 7.923530587764893,
+          "regime_counts": {
+            "BEAR": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -8.181342988986383
+            },
+            "buy_hold": {
+              "return": 8.181342988986383,
+              "max_drawdown": 4.207424226397674,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -8.181342988986383
+            },
+            "dual_ma_50_200": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -8.181342988986383
+            },
+            "volatility_target": {
+              "return": 8.181342988986383,
+              "max_drawdown": 4.207424226397674,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "regime_switch": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -8.181342988986383
+            },
+            "ma_boll_fixed": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": -8.181342988986383
+            }
+          }
+        }
+      ],
+      "summary": {
+        "cash": {
+          "continuous_oos_return": 0.0,
+          "continuous_excess_vs_buy_hold": 16.394987256568015,
+          "fold_compounded_return": 0.0,
+          "mean_fold_return": 0.0,
+          "median_fold_return": 0.0,
+          "mean_excess_vs_buy_hold": 2.0564699306713727,
+          "excess_win_rate": 0.5714285714285714,
+          "continuous_transactions": 0,
+          "continuous_turnover": 0.0,
+          "continuous_max_drawdown": 0.0,
+          "mean_fold_max_drawdown": 0.0
+        },
+        "buy_hold": {
+          "continuous_oos_return": -16.394987256568015,
+          "continuous_excess_vs_buy_hold": 0.0,
+          "fold_compounded_return": -45.28942040760357,
+          "mean_fold_return": -2.0564699306713727,
+          "median_fold_return": -4.713733583553969,
+          "mean_excess_vs_buy_hold": 0.0,
+          "excess_win_rate": 0.0,
+          "continuous_transactions": 1,
+          "continuous_turnover": 1.0,
+          "continuous_max_drawdown": 52.971765913510616,
+          "mean_fold_max_drawdown": 11.00134102105496
+        },
+        "sma200_trend": {
+          "continuous_oos_return": -28.91920664100136,
+          "continuous_excess_vs_buy_hold": -12.524219384433344,
+          "fold_compounded_return": -43.70583459740632,
+          "mean_fold_return": -1.9674625321756545,
+          "median_fold_return": 0.0,
+          "mean_excess_vs_buy_hold": 0.08900739849571823,
+          "excess_win_rate": 0.3333333333333333,
+          "continuous_transactions": 18,
+          "continuous_turnover": 18.0,
+          "continuous_max_drawdown": 48.11207381949391,
+          "mean_fold_max_drawdown": 6.989803756474728
+        },
+        "dual_ma_50_200": {
+          "continuous_oos_return": -19.093099016333127,
+          "continuous_excess_vs_buy_hold": -2.698111759765112,
+          "fold_compounded_return": -35.92380935898473,
+          "mean_fold_return": -1.682516909551655,
+          "median_fold_return": 0.0,
+          "mean_excess_vs_buy_hold": 0.3739530211197176,
+          "excess_win_rate": 0.3333333333333333,
+          "continuous_transactions": 4,
+          "continuous_turnover": 4.0,
+          "continuous_max_drawdown": 40.939160814775086,
+          "mean_fold_max_drawdown": 6.1005603859298905
+        },
+        "volatility_target": {
+          "continuous_oos_return": -24.023002483667256,
+          "continuous_excess_vs_buy_hold": -7.62801522709924,
+          "fold_compounded_return": -49.658741856537084,
+          "mean_fold_return": -2.491320625761558,
+          "median_fold_return": -4.572018108552878,
+          "mean_excess_vs_buy_hold": -0.4348506950901855,
+          "excess_win_rate": 0.14285714285714285,
+          "continuous_transactions": 17,
+          "continuous_turnover": 3.516321776097176,
+          "continuous_max_drawdown": 55.03801457546055,
+          "mean_fold_max_drawdown": 10.907506630618919
+        },
+        "regime_switch": {
+          "continuous_oos_return": 14.328536089852161,
+          "continuous_excess_vs_buy_hold": 30.723523346420176,
+          "fold_compounded_return": -11.354282573708241,
+          "mean_fold_return": -0.03911545899540799,
+          "median_fold_return": 0.0,
+          "mean_excess_vs_buy_hold": 2.0173544716759646,
+          "excess_win_rate": 0.2857142857142857,
+          "continuous_transactions": 2,
+          "continuous_turnover": 2.0,
+          "continuous_max_drawdown": 32.02251526449771,
+          "mean_fold_max_drawdown": 6.420296603268858
+        },
+        "ma_boll_fixed": {
+          "continuous_oos_return": -41.874,
+          "continuous_excess_vs_buy_hold": -25.479012743431987,
+          "fold_compounded_return": -36.62694515030105,
+          "mean_fold_return": -2.067761904761905,
+          "median_fold_return": -0.576,
+          "mean_excess_vs_buy_hold": -0.011291974090532028,
+          "excess_win_rate": 0.5238095238095238,
+          "continuous_transactions": 86,
+          "continuous_turnover": null,
+          "continuous_max_drawdown": 45.69,
+          "mean_fold_max_drawdown": 3.2142857142857144
+        }
+      }
+    },
+    {
+      "symbol": "SOL",
+      "data_start": "2023-08-04 00:00:00",
+      "data_end": "2026-08-02 00:00:00",
+      "data_rows": 1095,
+      "folds": [
+        {
+          "fold": 1,
+          "test_start": "2024-11-08 00:00:00",
+          "test_end": "2024-12-07 00:00:00",
+          "market_return": 19.159369527145365,
+          "regime_counts": {
+            "BULL": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -18.73296798943569
+            },
+            "buy_hold": {
+              "return": 18.73296798943569,
+              "max_drawdown": 12.13701829505643,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 18.73296798943569,
+              "max_drawdown": 12.13701829505643,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "dual_ma_50_200": {
+              "return": 18.73296798943569,
+              "max_drawdown": 12.13701829505643,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "volatility_target": {
+              "return": 11.83755167925742,
+              "max_drawdown": 7.320189293368317,
+              "transactions": 2,
+              "turnover": 0.7471849592129597,
+              "mean_exposure": 0.6110768669127482,
+              "excess_vs_buy_hold": -6.89541631017827
+            },
+            "regime_switch": {
+              "return": 18.73296798943569,
+              "max_drawdown": 12.13701829505643,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "ma_boll_fixed": {
+              "return": 3.231,
+              "max_drawdown": 7.049999999999999,
+              "transactions": 6,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": -15.50196798943569
+            }
+          }
+        },
+        {
+          "fold": 2,
+          "test_start": "2024-12-08 00:00:00",
+          "test_end": "2025-01-06 00:00:00",
+          "market_return": -7.931820099569665,
+          "regime_counts": {
+            "BULL": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 10.287243620576959
+            },
+            "buy_hold": {
+              "return": -10.287243620576959,
+              "max_drawdown": 23.837650831153486,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": -10.287243620576959,
+              "max_drawdown": 23.837650831153486,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "dual_ma_50_200": {
+              "return": -10.287243620576959,
+              "max_drawdown": 23.837650831153486,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "volatility_target": {
+              "return": -8.652353111730992,
+              "max_drawdown": 18.47114758505024,
+              "transactions": 4,
+              "turnover": 1.1526069922958533,
+              "mean_exposure": 0.7181820623323607,
+              "excess_vs_buy_hold": 1.6348905088459667
+            },
+            "regime_switch": {
+              "return": -10.287243620576959,
+              "max_drawdown": 23.837650831153486,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "ma_boll_fixed": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": 10.287243620576959
+            }
+          }
+        },
+        {
+          "fold": 3,
+          "test_start": "2025-01-07 00:00:00",
+          "test_end": "2025-02-05 00:00:00",
+          "market_return": -2.9925310382351356,
+          "regime_counts": {
+            "BULL": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 12.012833651546861
+            },
+            "buy_hold": {
+              "return": -12.012833651546861,
+              "max_drawdown": 25.136466007558123,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": -12.012833651546861,
+              "max_drawdown": 25.136466007558123,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "dual_ma_50_200": {
+              "return": -12.012833651546861,
+              "max_drawdown": 25.136466007558123,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "volatility_target": {
+              "return": 0.5754960489332772,
+              "max_drawdown": 12.296287967881007,
+              "transactions": 3,
+              "turnover": 1.045691851117641,
+              "mean_exposure": 0.526748638664896,
+              "excess_vs_buy_hold": 12.588329700480138
+            },
+            "regime_switch": {
+              "return": -12.012833651546861,
+              "max_drawdown": 25.136466007558123,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "ma_boll_fixed": {
+              "return": -10.608,
+              "max_drawdown": 10.61,
+              "transactions": 3,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": 1.404833651546861
+            }
+          }
+        },
+        {
+          "fold": 4,
+          "test_start": "2025-02-06 00:00:00",
+          "test_end": "2025-03-07 00:00:00",
+          "market_return": -26.458794977313506,
+          "regime_counts": {
+            "BULL": 12,
+            "RANGE": 18
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 30.417227072336196
+            },
+            "buy_hold": {
+              "return": -30.417227072336196,
+              "max_drawdown": 32.498628223674366,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": -13.237225660327823,
+              "max_drawdown": 13.301032274155707,
+              "transactions": 2,
+              "turnover": 2.0,
+              "mean_exposure": 0.4000000000000001,
+              "excess_vs_buy_hold": 17.180001412008373
+            },
+            "dual_ma_50_200": {
+              "return": -30.417227072336196,
+              "max_drawdown": 32.498628223674366,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "volatility_target": {
+              "return": -19.592795536765518,
+              "max_drawdown": 26.96976196593467,
+              "transactions": 6,
+              "turnover": 1.530948674208832,
+              "mean_exposure": 0.614512873670561,
+              "excess_vs_buy_hold": 10.824431535570678
+            },
+            "regime_switch": {
+              "return": -30.417227072336196,
+              "max_drawdown": 32.498628223674366,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "ma_boll_fixed": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": 30.417227072336196
+            }
+          }
+        },
+        {
+          "fold": 5,
+          "test_start": "2025-03-08 00:00:00",
+          "test_end": "2025-04-06 00:00:00",
+          "market_return": -22.699073060360554,
+          "regime_counts": {
+            "RANGE": 5,
+            "BEAR": 25
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 25.612947924448026
+            },
+            "buy_hold": {
+              "return": -25.612947924448026,
+              "max_drawdown": 26.26705653021441,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 25.612947924448026
+            },
+            "dual_ma_50_200": {
+              "return": -15.174524122838918,
+              "max_drawdown": 13.64134004817167,
+              "transactions": 2,
+              "turnover": 2.0,
+              "mean_exposure": 0.2,
+              "excess_vs_buy_hold": 10.438423801609108
+            },
+            "volatility_target": {
+              "return": -13.812046815107436,
+              "max_drawdown": 15.860904927945807,
+              "transactions": 3,
+              "turnover": 0.6012666158069669,
+              "mean_exposure": 0.4239836583570446,
+              "excess_vs_buy_hold": 11.80090110934059
+            },
+            "regime_switch": {
+              "return": -12.939741400718518,
+              "max_drawdown": 13.64134004817167,
+              "transactions": 2,
+              "turnover": 2.0,
+              "mean_exposure": 0.16666666666666666,
+              "excess_vs_buy_hold": 12.673206523729508
+            },
+            "ma_boll_fixed": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": 25.612947924448026
+            }
+          }
+        },
+        {
+          "fold": 6,
+          "test_start": "2025-04-07 00:00:00",
+          "test_end": "2025-05-06 00:00:00",
+          "market_return": 37.28385830451444,
+          "regime_counts": {
+            "BEAR": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -35.78715901662078
+            },
+            "buy_hold": {
+              "return": 35.78715901662078,
+              "max_drawdown": 5.637495902982645,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -35.78715901662078
+            },
+            "dual_ma_50_200": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -35.78715901662078
+            },
+            "volatility_target": {
+              "return": 15.696435701544376,
+              "max_drawdown": 5.034598538071034,
+              "transactions": 5,
+              "turnover": 1.0943550303488718,
+              "mean_exposure": 0.5998350553256102,
+              "excess_vs_buy_hold": -20.090723315076403
+            },
+            "regime_switch": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -35.78715901662078
+            },
+            "ma_boll_fixed": {
+              "return": -0.072,
+              "max_drawdown": 4.19,
+              "transactions": 5,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": -35.85915901662078
+            }
+          }
+        },
+        {
+          "fold": 7,
+          "test_start": "2025-05-07 00:00:00",
+          "test_end": "2025-06-05 00:00:00",
+          "market_return": -2.0567472169427115,
+          "regime_counts": {
+            "BEAR": 19,
+            "RANGE": 10,
+            "BULL": 1
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 3.830800556241354
+            },
+            "buy_hold": {
+              "return": -3.830800556241354,
+              "max_drawdown": 21.474829931972792,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": -7.86583944055943,
+              "max_drawdown": 7.86583944055943,
+              "transactions": 2,
+              "turnover": 2.0,
+              "mean_exposure": 0.03333333333333333,
+              "excess_vs_buy_hold": -4.035038884318077
+            },
+            "dual_ma_50_200": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 3.830800556241354
+            },
+            "volatility_target": {
+              "return": -4.460611997105202,
+              "max_drawdown": 19.574696688462616,
+              "transactions": 4,
+              "turnover": 1.478400082264176,
+              "mean_exposure": 0.8195619919883194,
+              "excess_vs_buy_hold": -0.6298114408638482
+            },
+            "regime_switch": {
+              "return": -12.68041398601395,
+              "max_drawdown": 12.680413986013955,
+              "transactions": 2,
+              "turnover": 2.0,
+              "mean_exposure": 0.1,
+              "excess_vs_buy_hold": -8.849613429772596
+            },
+            "ma_boll_fixed": {
+              "return": -11.72,
+              "max_drawdown": 10.17,
+              "transactions": 4,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": -7.889199443758647
+            }
+          }
+        },
+        {
+          "fold": 8,
+          "test_start": "2025-06-06 00:00:00",
+          "test_end": "2025-07-05 00:00:00",
+          "market_return": -0.18940675099776705,
+          "regime_counts": {
+            "BEAR": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -0.12097688837364728
+            },
+            "buy_hold": {
+              "return": 0.12097688837364728,
+              "max_drawdown": 20.233769379844954,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -0.12097688837364728
+            },
+            "dual_ma_50_200": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -0.12097688837364728
+            },
+            "volatility_target": {
+              "return": -0.13990059099074914,
+              "max_drawdown": 17.530410021915742,
+              "transactions": 3,
+              "turnover": 1.2188476952170983,
+              "mean_exposure": 0.7939187453688861,
+              "excess_vs_buy_hold": -0.2608774793643964
+            },
+            "regime_switch": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -0.12097688837364728
+            },
+            "ma_boll_fixed": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": -0.12097688837364728
+            }
+          }
+        },
+        {
+          "fold": 9,
+          "test_start": "2025-07-06 00:00:00",
+          "test_end": "2025-08-04 00:00:00",
+          "market_return": 11.648887132885545,
+          "regime_counts": {
+            "BEAR": 12,
+            "RANGE": 18
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -12.499496437144696
+            },
+            "buy_hold": {
+              "return": 12.499496437144696,
+              "max_drawdown": 22.955760816723387,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": -7.360853438548254,
+              "max_drawdown": 24.567389499270778,
+              "transactions": 2,
+              "turnover": 2.0,
+              "mean_exposure": 0.6,
+              "excess_vs_buy_hold": -19.86034987569295
+            },
+            "dual_ma_50_200": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -12.499496437144696
+            },
+            "volatility_target": {
+              "return": 11.704539023546356,
+              "max_drawdown": 19.530145696541716,
+              "transactions": 3,
+              "turnover": 1.1123499578885134,
+              "mean_exposure": 0.8189616190649759,
+              "excess_vs_buy_hold": -0.7949574135983397
+            },
+            "regime_switch": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -12.499496437144696
+            },
+            "ma_boll_fixed": {
+              "return": -9.737,
+              "max_drawdown": 13.600000000000001,
+              "transactions": 11,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": -22.236496437144694
+            }
+          }
+        },
+        {
+          "fold": 10,
+          "test_start": "2025-08-05 00:00:00",
+          "test_end": "2025-09-03 00:00:00",
+          "market_return": 28.447803034919872,
+          "regime_counts": {
+            "RANGE": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -21.703480830582002
+            },
+            "buy_hold": {
+              "return": 21.703480830582002,
+              "max_drawdown": 12.550245645377393,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 21.703480830582002,
+              "max_drawdown": 12.550245645377393,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "dual_ma_50_200": {
+              "return": 25.753093880341147,
+              "max_drawdown": 12.550245645377398,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 0.9666666666666667,
+              "excess_vs_buy_hold": 4.049613049759145
+            },
+            "volatility_target": {
+              "return": 14.147673221095003,
+              "max_drawdown": 9.465084735832196,
+              "transactions": 4,
+              "turnover": 1.03800505346537,
+              "mean_exposure": 0.6474678430902535,
+              "excess_vs_buy_hold": -7.555807609486999
+            },
+            "regime_switch": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -21.703480830582002
+            },
+            "ma_boll_fixed": {
+              "return": 7.625,
+              "max_drawdown": 5.970000000000001,
+              "transactions": 6,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": -14.078480830582002
+            }
+          }
+        },
+        {
+          "fold": 11,
+          "test_start": "2025-09-04 00:00:00",
+          "test_end": "2025-10-03 00:00:00",
+          "market_return": 15.085013839462235,
+          "regime_counts": {
+            "RANGE": 4,
+            "BULL": 26
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -8.153553520541234
+            },
+            "buy_hold": {
+              "return": 8.153553520541234,
+              "max_drawdown": 22.125252525252527,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 8.153553520541234,
+              "max_drawdown": 22.125252525252527,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "dual_ma_50_200": {
+              "return": 8.153553520541234,
+              "max_drawdown": 22.125252525252527,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "volatility_target": {
+              "return": -1.5380360454998687,
+              "max_drawdown": 21.297464351118325,
+              "transactions": 7,
+              "turnover": 1.3069745267622892,
+              "mean_exposure": 0.7517072444675655,
+              "excess_vs_buy_hold": -9.691589566041102
+            },
+            "regime_switch": {
+              "return": 10.470193726796584,
+              "max_drawdown": 22.125252525252527,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 0.8666666666666667,
+              "excess_vs_buy_hold": 2.31664020625535
+            },
+            "ma_boll_fixed": {
+              "return": -7.786,
+              "max_drawdown": 11.59,
+              "transactions": 6,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": -15.939553520541233
+            }
+          }
+        },
+        {
+          "fold": 12,
+          "test_start": "2025-10-04 00:00:00",
+          "test_end": "2025-11-02 00:00:00",
+          "market_return": -17.62046870885632,
+          "regime_counts": {
+            "BULL": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 21.073686663791445
+            },
+            "buy_hold": {
+              "return": -21.073686663791445,
+              "max_drawdown": 23.55498170862921,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": -21.073686663791445,
+              "max_drawdown": 23.55498170862921,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "dual_ma_50_200": {
+              "return": -21.073686663791445,
+              "max_drawdown": 23.55498170862921,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "volatility_target": {
+              "return": -14.614898472006422,
+              "max_drawdown": 15.339257771856312,
+              "transactions": 4,
+              "turnover": 1.125448092807877,
+              "mean_exposure": 0.5653189477404487,
+              "excess_vs_buy_hold": 6.458788191785024
+            },
+            "regime_switch": {
+              "return": -21.073686663791445,
+              "max_drawdown": 23.55498170862921,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "ma_boll_fixed": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": 21.073686663791445
+            }
+          }
+        },
+        {
+          "fold": 13,
+          "test_start": "2025-11-03 00:00:00",
+          "test_end": "2025-12-02 00:00:00",
+          "market_return": -16.48801637962182,
+          "regime_counts": {
+            "BULL": 1,
+            "RANGE": 21,
+            "BEAR": 8
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 27.670007260865493
+            },
+            "buy_hold": {
+              "return": -27.670007260865493,
+              "max_drawdown": 24.296216603908928,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": -15.20676863171988,
+              "max_drawdown": 2.0979999999999994,
+              "transactions": 2,
+              "turnover": 2.0,
+              "mean_exposure": 0.03333333333333333,
+              "excess_vs_buy_hold": 12.463238629145613
+            },
+            "dual_ma_50_200": {
+              "return": -34.84513836810464,
+              "max_drawdown": 25.33443786982249,
+              "transactions": 2,
+              "turnover": 2.0,
+              "mean_exposure": 0.6666666666666666,
+              "excess_vs_buy_hold": -7.1751311072391495
+            },
+            "volatility_target": {
+              "return": -21.72476388747655,
+              "max_drawdown": 16.2868925775501,
+              "transactions": 5,
+              "turnover": 1.527142477986704,
+              "mean_exposure": 0.6509921724547468,
+              "excess_vs_buy_hold": 5.945243373388944
+            },
+            "regime_switch": {
+              "return": -29.315145017999413,
+              "max_drawdown": 23.740362201900663,
+              "transactions": 2,
+              "turnover": 2.0,
+              "mean_exposure": 0.7333333333333333,
+              "excess_vs_buy_hold": -1.64513775713392
+            },
+            "ma_boll_fixed": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": 27.670007260865493
+            }
+          }
+        },
+        {
+          "fold": 14,
+          "test_start": "2025-12-03 00:00:00",
+          "test_end": "2026-01-01 00:00:00",
+          "market_return": -12.283127116886694,
+          "regime_counts": {
+            "BEAR": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 10.407613587825582
+            },
+            "buy_hold": {
+              "return": -10.407613587825582,
+              "max_drawdown": 17.329093799682042,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 10.407613587825582
+            },
+            "dual_ma_50_200": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 10.407613587825582
+            },
+            "volatility_target": {
+              "return": -8.008462774998282,
+              "max_drawdown": 14.051696227706998,
+              "transactions": 3,
+              "turnover": 1.004463099965278,
+              "mean_exposure": 0.7870142778812361,
+              "excess_vs_buy_hold": 2.3991508128272994
+            },
+            "regime_switch": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 10.407613587825582
+            },
+            "ma_boll_fixed": {
+              "return": -3.396,
+              "max_drawdown": 6.67,
+              "transactions": 1,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": 7.011613587825582
+            }
+          }
+        },
+        {
+          "fold": 15,
+          "test_start": "2026-01-02 00:00:00",
+          "test_end": "2026-01-31 00:00:00",
+          "market_return": -20.190490588857813,
+          "regime_counts": {
+            "BEAR": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 18.552489981061406
+            },
+            "buy_hold": {
+              "return": -18.552489981061406,
+              "max_drawdown": 28.02508691799033,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 18.552489981061406
+            },
+            "dual_ma_50_200": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 18.552489981061406
+            },
+            "volatility_target": {
+              "return": -16.840958922918492,
+              "max_drawdown": 26.51261220736563,
+              "transactions": 2,
+              "turnover": 1.1382039294778261,
+              "mean_exposure": 0.9764036732278147,
+              "excess_vs_buy_hold": 1.7115310581429135
+            },
+            "regime_switch": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 18.552489981061406
+            },
+            "ma_boll_fixed": {
+              "return": -12.84,
+              "max_drawdown": 15.07,
+              "transactions": 7,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": 5.712489981061406
+            }
+          }
+        },
+        {
+          "fold": 16,
+          "test_start": "2026-02-01 00:00:00",
+          "test_end": "2026-03-02 00:00:00",
+          "market_return": -14.039091179680529,
+          "regime_counts": {
+            "BEAR": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 19.66056296421894
+            },
+            "buy_hold": {
+              "return": -19.66056296421894,
+              "max_drawdown": 25.49019607843137,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 19.66056296421894
+            },
+            "dual_ma_50_200": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 19.66056296421894
+            },
+            "volatility_target": {
+              "return": -14.134887995158973,
+              "max_drawdown": 17.348181998836594,
+              "transactions": 3,
+              "turnover": 1.075224152523772,
+              "mean_exposure": 0.5196593117053928,
+              "excess_vs_buy_hold": 5.525674969059967
+            },
+            "regime_switch": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 19.66056296421894
+            },
+            "ma_boll_fixed": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": 19.66056296421894
+            }
+          }
+        },
+        {
+          "fold": 17,
+          "test_start": "2026-03-03 00:00:00",
+          "test_end": "2026-04-01 00:00:00",
+          "market_return": -6.6574680924456615,
+          "regime_counts": {
+            "BEAR": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 8.278219184162626
+            },
+            "buy_hold": {
+              "return": -8.278219184162626,
+              "max_drawdown": 15.61330561330562,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 8.278219184162626
+            },
+            "dual_ma_50_200": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 8.278219184162626
+            },
+            "volatility_target": {
+              "return": -9.63461496057385,
+              "max_drawdown": 14.254626351506303,
+              "transactions": 2,
+              "turnover": 0.8898633679052932,
+              "mean_exposure": 0.7574313434526212,
+              "excess_vs_buy_hold": -1.3563957764112242
+            },
+            "regime_switch": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 8.278219184162626
+            },
+            "ma_boll_fixed": {
+              "return": -7.559,
+              "max_drawdown": 8.870000000000001,
+              "transactions": 5,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": 0.7192191841626263
+            }
+          }
+        },
+        {
+          "fold": 18,
+          "test_start": "2026-04-02 00:00:00",
+          "test_end": "2026-05-01 00:00:00",
+          "market_return": 6.105903217633646,
+          "regime_counts": {
+            "BEAR": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -1.0011050656450582
+            },
+            "buy_hold": {
+              "return": 1.0011050656450582,
+              "max_drawdown": 6.749017405951689,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -1.0011050656450582
+            },
+            "dual_ma_50_200": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -1.0011050656450582
+            },
+            "volatility_target": {
+              "return": 0.5468990964990983,
+              "max_drawdown": 6.461229048434208,
+              "transactions": 4,
+              "turnover": 1.2156997633403401,
+              "mean_exposure": 0.9112930544664227,
+              "excess_vs_buy_hold": -0.4542059691459599
+            },
+            "regime_switch": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -1.0011050656450582
+            },
+            "ma_boll_fixed": {
+              "return": -3.58,
+              "max_drawdown": 4.19,
+              "transactions": 2,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": -4.581105065645058
+            }
+          }
+        },
+        {
+          "fold": 19,
+          "test_start": "2026-05-02 00:00:00",
+          "test_end": "2026-05-31 00:00:00",
+          "market_return": -2.1599810111559536,
+          "regime_counts": {
+            "BEAR": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 3.6407718356142316
+            },
+            "buy_hold": {
+              "return": -3.6407718356142316,
+              "max_drawdown": 15.74406901509704,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 3.6407718356142316
+            },
+            "dual_ma_50_200": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 3.6407718356142316
+            },
+            "volatility_target": {
+              "return": -3.6407718356142316,
+              "max_drawdown": 15.74406901509704,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "regime_switch": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 3.6407718356142316
+            },
+            "ma_boll_fixed": {
+              "return": -8.843,
+              "max_drawdown": 9.84,
+              "transactions": 4,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": -5.202228164385769
+            }
+          }
+        },
+        {
+          "fold": 20,
+          "test_start": "2026-06-01 00:00:00",
+          "test_end": "2026-06-30 00:00:00",
+          "market_return": -9.362696850393704,
+          "regime_counts": {
+            "BEAR": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 12.523377168616701
+            },
+            "buy_hold": {
+              "return": -12.523377168616701,
+              "max_drawdown": 23.474409448818896,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 12.523377168616701
+            },
+            "dual_ma_50_200": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 12.523377168616701
+            },
+            "volatility_target": {
+              "return": -14.304859849239037,
+              "max_drawdown": 23.474409448818896,
+              "transactions": 4,
+              "turnover": 1.4655332934080447,
+              "mean_exposure": 0.8189631606600265,
+              "excess_vs_buy_hold": -1.7814826806223358
+            },
+            "regime_switch": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 12.523377168616701
+            },
+            "ma_boll_fixed": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": 12.523377168616701
+            }
+          }
+        },
+        {
+          "fold": 21,
+          "test_start": "2026-07-01 00:00:00",
+          "test_end": "2026-07-30 00:00:00",
+          "market_return": -3.8084172476116507,
+          "regime_counts": {
+            "BEAR": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 0.9816028955434208
+            },
+            "buy_hold": {
+              "return": -0.9816028955434208,
+              "max_drawdown": 10.517367014816614,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 0.9816028955434208
+            },
+            "dual_ma_50_200": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 0.9816028955434208
+            },
+            "volatility_target": {
+              "return": -1.1244257354988796,
+              "max_drawdown": 9.42741251651117,
+              "transactions": 2,
+              "turnover": 0.9549979593707449,
+              "mean_exposure": 0.9120276816863345,
+              "excess_vs_buy_hold": -0.14282283995545875
+            },
+            "regime_switch": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 0.9816028955434208
+            },
+            "ma_boll_fixed": {
+              "return": -4.306,
+              "max_drawdown": 6.12,
+              "transactions": 4,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": -3.324397104456579
+            }
+          }
+        }
+      ],
+      "summary": {
+        "cash": {
+          "continuous_oos_return": 0.0,
+          "continuous_excess_vs_buy_hold": 62.85045164654046,
+          "fold_compounded_return": 0.0,
+          "mean_fold_return": 0.0,
+          "median_fold_return": 0.0,
+          "mean_excess_vs_buy_hold": 5.092887838976483,
+          "excess_win_rate": 0.6666666666666666,
+          "continuous_transactions": 0,
+          "continuous_turnover": 0.0,
+          "continuous_max_drawdown": 0.0,
+          "mean_fold_max_drawdown": 0.0
+        },
+        "buy_hold": {
+          "continuous_oos_return": -62.85045164654046,
+          "continuous_excess_vs_buy_hold": 0.0,
+          "fold_compounded_return": -75.6961070362285,
+          "mean_fold_return": -5.092887838976483,
+          "median_fold_return": -8.278219184162626,
+          "mean_excess_vs_buy_hold": 0.0,
+          "excess_win_rate": 0.0,
+          "continuous_transactions": 1,
+          "continuous_turnover": 1.0,
+          "continuous_max_drawdown": 76.2568233003779,
+          "mean_fold_max_drawdown": 19.79275798554487
+        },
+        "sma200_trend": {
+          "continuous_oos_return": -30.566617596428813,
+          "continuous_excess_vs_buy_hold": 32.28383405011165,
+          "fold_compounded_return": -38.86072120582986,
+          "mean_fold_return": -1.831164226976749,
+          "median_fold_return": 0.0,
+          "mean_excess_vs_buy_hold": 3.261723611999734,
+          "excess_win_rate": 0.47619047619047616,
+          "continuous_transactions": 8,
+          "continuous_turnover": 8.0,
+          "continuous_max_drawdown": 46.84087947547351,
+          "mean_fold_max_drawdown": 7.960660772714909
+        },
+        "dual_ma_50_200": {
+          "continuous_oos_return": -55.11956879452213,
+          "continuous_excess_vs_buy_hold": 7.730882852018333,
+          "fold_compounded_return": -61.30979699818958,
+          "mean_fold_return": -3.389097052803664,
+          "median_fold_return": 0.0,
+          "mean_excess_vs_buy_hold": 1.7037907861728183,
+          "excess_win_rate": 0.47619047619047616,
+          "continuous_transactions": 4,
+          "continuous_turnover": 4.0,
+          "continuous_max_drawdown": 65.63894528747592,
+          "mean_fold_max_drawdown": 9.086477197842653
+        },
+        "volatility_target": {
+          "continuous_oos_return": -58.193245116866755,
+          "continuous_excess_vs_buy_hold": 4.657206529673708,
+          "fold_compounded_return": -67.86269750571942,
+          "mean_fold_return": -4.653133036181378,
+          "median_fold_return": -4.460611997105202,
+          "mean_excess_vs_buy_hold": 0.4397548027951039,
+          "excess_win_rate": 0.42857142857142855,
+          "continuous_transactions": 54,
+          "continuous_turnover": 8.8702163103307,
+          "continuous_max_drawdown": 70.27600743579494,
+          "mean_fold_max_drawdown": 15.821479949324043
+        },
+        "regime_switch": {
+          "continuous_oos_return": -65.30079510891285,
+          "continuous_excess_vs_buy_hold": -2.4503434623723876,
+          "fold_compounded_return": -69.44575810175289,
+          "mean_fold_return": -4.739196652226242,
+          "median_fold_return": 0.0,
+          "mean_excess_vs_buy_hold": 0.35369118675024136,
+          "excess_win_rate": 0.42857142857142855,
+          "continuous_transactions": 6,
+          "continuous_turnover": 6.0,
+          "continuous_max_drawdown": 74.98941540101028,
+          "mean_fold_max_drawdown": 9.016767325114783
+        },
+        "ma_boll_fixed": {
+          "continuous_oos_return": -52.682,
+          "continuous_excess_vs_buy_hold": 10.168451646540461,
+          "fold_compounded_return": -52.25840517129263,
+          "mean_fold_return": -3.313857142857143,
+          "median_fold_return": -0.072,
+          "mean_excess_vs_buy_hold": 1.7790306961193398,
+          "excess_win_rate": 0.5238095238095238,
+          "continuous_transactions": 132,
+          "continuous_turnover": null,
+          "continuous_max_drawdown": 56.410000000000004,
+          "mean_fold_max_drawdown": 5.425714285714286
+        }
+      }
+    },
+    {
+      "symbol": "UNI",
+      "data_start": "2023-08-04 00:00:00",
+      "data_end": "2026-08-02 00:00:00",
+      "data_rows": 1095,
+      "folds": [
+        {
+          "fold": 1,
+          "test_start": "2024-11-08 00:00:00",
+          "test_end": "2024-12-07 00:00:00",
+          "market_return": 103.98689857691438,
+          "regime_counts": {
+            "RANGE": 7,
+            "BULL": 23
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -98.6529367722492
+            },
+            "buy_hold": {
+              "return": 98.6529367722492,
+              "max_drawdown": 12.366052293184735,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 98.6529367722492,
+              "max_drawdown": 12.366052293184735,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "dual_ma_50_200": {
+              "return": 88.16747794080987,
+              "max_drawdown": 8.171853686379581,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 0.6,
+              "excess_vs_buy_hold": -10.485458831439331
+            },
+            "volatility_target": {
+              "return": 36.95651534177817,
+              "max_drawdown": 4.461443337861475,
+              "transactions": 4,
+              "turnover": 0.9125071827471936,
+              "mean_exposure": 0.38676178979412135,
+              "excess_vs_buy_hold": -61.696421430471034
+            },
+            "regime_switch": {
+              "return": 116.1889950128121,
+              "max_drawdown": 7.073170731707309,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 0.7666666666666667,
+              "excess_vs_buy_hold": 17.536058240562895
+            },
+            "ma_boll_fixed": {
+              "return": 11.665,
+              "max_drawdown": 5.24,
+              "transactions": 10,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": -86.98793677224921
+            }
+          }
+        },
+        {
+          "fold": 2,
+          "test_start": "2024-12-08 00:00:00",
+          "test_end": "2025-01-06 00:00:00",
+          "market_return": -18.945217999032305,
+          "regime_counts": {
+            "BULL": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 18.286651346881623
+            },
+            "buy_hold": {
+              "return": -18.286651346881623,
+              "max_drawdown": 31.584323423471844,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": -18.286651346881623,
+              "max_drawdown": 31.584323423471844,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "dual_ma_50_200": {
+              "return": -18.286651346881623,
+              "max_drawdown": 31.584323423471844,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "volatility_target": {
+              "return": -4.248739800230106,
+              "max_drawdown": 11.751729954888491,
+              "transactions": 3,
+              "turnover": 0.6180332694715641,
+              "mean_exposure": 0.3896851732754724,
+              "excess_vs_buy_hold": 14.037911546651518
+            },
+            "regime_switch": {
+              "return": -18.286651346881623,
+              "max_drawdown": 31.584323423471844,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "ma_boll_fixed": {
+              "return": -20.183,
+              "max_drawdown": 26.090000000000003,
+              "transactions": 8,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": -1.8963486531183769
+            }
+          }
+        },
+        {
+          "fold": 3,
+          "test_start": "2025-01-07 00:00:00",
+          "test_end": "2025-02-05 00:00:00",
+          "market_return": -31.46108935038062,
+          "regime_counts": {
+            "BULL": 28,
+            "RANGE": 2
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 39.775533566990184
+            },
+            "buy_hold": {
+              "return": -39.775533566990184,
+              "max_drawdown": 39.459279038718286,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": -48.98253138350842,
+              "max_drawdown": 47.55534616092959,
+              "transactions": 4,
+              "turnover": 4.0,
+              "mean_exposure": 0.9333333333333333,
+              "excess_vs_buy_hold": -9.20699781651824
+            },
+            "dual_ma_50_200": {
+              "return": -39.775533566990184,
+              "max_drawdown": 39.459279038718286,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "volatility_target": {
+              "return": -22.260553181282628,
+              "max_drawdown": 23.24553123011186,
+              "transactions": 5,
+              "turnover": 1.004182868111641,
+              "mean_exposure": 0.5590995004683614,
+              "excess_vs_buy_hold": 17.514980385707556
+            },
+            "regime_switch": {
+              "return": -39.775533566990184,
+              "max_drawdown": 39.459279038718286,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "ma_boll_fixed": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": 39.775533566990184
+            }
+          }
+        },
+        {
+          "fold": 4,
+          "test_start": "2025-02-06 00:00:00",
+          "test_end": "2025-03-07 00:00:00",
+          "market_return": -21.304541406945678,
+          "regime_counts": {
+            "RANGE": 25,
+            "BULL": 5
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 25.364693533768357
+            },
+            "buy_hold": {
+              "return": -25.364693533768357,
+              "max_drawdown": 29.69371519490851,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": -14.33904099455151,
+              "max_drawdown": 14.339040994551505,
+              "transactions": 4,
+              "turnover": 4.0,
+              "mean_exposure": 0.16666666666666674,
+              "excess_vs_buy_hold": 11.025652539216846
+            },
+            "dual_ma_50_200": {
+              "return": -25.364693533768357,
+              "max_drawdown": 29.69371519490851,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "volatility_target": {
+              "return": -16.70489868508088,
+              "max_drawdown": 19.069667970442556,
+              "transactions": 3,
+              "turnover": 0.7972433528345109,
+              "mean_exposure": 0.5212902539844776,
+              "excess_vs_buy_hold": 8.659794848687476
+            },
+            "regime_switch": {
+              "return": -25.364693533768357,
+              "max_drawdown": 29.69371519490851,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "ma_boll_fixed": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": 25.364693533768357
+            }
+          }
+        },
+        {
+          "fold": 5,
+          "test_start": "2025-03-08 00:00:00",
+          "test_end": "2025-04-06 00:00:00",
+          "market_return": -28.80669923237963,
+          "regime_counts": {
+            "RANGE": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 29.36370560132936
+            },
+            "buy_hold": {
+              "return": -29.36370560132936,
+              "max_drawdown": 28.80669923237963,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 29.36370560132936
+            },
+            "dual_ma_50_200": {
+              "return": -2.8775284913106547,
+              "max_drawdown": 2.1116639218422963,
+              "transactions": 2,
+              "turnover": 2.0,
+              "mean_exposure": 0.03333333333333333,
+              "excess_vs_buy_hold": 26.486177110018705
+            },
+            "volatility_target": {
+              "return": -19.029542067040282,
+              "max_drawdown": 18.72818472077002,
+              "transactions": 3,
+              "turnover": 0.7469987149431948,
+              "mean_exposure": 0.5330658746787549,
+              "excess_vs_buy_hold": 10.334163534289079
+            },
+            "regime_switch": {
+              "return": -29.36370560132936,
+              "max_drawdown": 28.80669923237963,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "ma_boll_fixed": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": 29.36370560132936
+            }
+          }
+        },
+        {
+          "fold": 6,
+          "test_start": "2025-04-07 00:00:00",
+          "test_end": "2025-05-06 00:00:00",
+          "market_return": -3.026752587385284,
+          "regime_counts": {
+            "BEAR": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 4.707601297174002
+            },
+            "buy_hold": {
+              "return": -4.707601297174002,
+              "max_drawdown": 17.686060003315113,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 4.707601297174002
+            },
+            "dual_ma_50_200": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 4.707601297174002
+            },
+            "volatility_target": {
+              "return": -4.961731710215211,
+              "max_drawdown": 11.386095301029744,
+              "transactions": 5,
+              "turnover": 1.047311370421519,
+              "mean_exposure": 0.5416146909815548,
+              "excess_vs_buy_hold": -0.2541304130412092
+            },
+            "regime_switch": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 4.707601297174002
+            },
+            "ma_boll_fixed": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": 4.707601297174002
+            }
+          }
+        },
+        {
+          "fold": 7,
+          "test_start": "2025-05-07 00:00:00",
+          "test_end": "2025-06-05 00:00:00",
+          "market_return": 20.98461538461538,
+          "regime_counts": {
+            "BEAR": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -16.252581724697702
+            },
+            "buy_hold": {
+              "return": 16.252581724697702,
+              "max_drawdown": 24.037061548643283,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -16.252581724697702
+            },
+            "dual_ma_50_200": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -16.252581724697702
+            },
+            "volatility_target": {
+              "return": 15.407056603484381,
+              "max_drawdown": 9.33873872888158,
+              "transactions": 4,
+              "turnover": 1.6443733390839963,
+              "mean_exposure": 0.39774926763406465,
+              "excess_vs_buy_hold": -0.8455251212133206
+            },
+            "regime_switch": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -16.252581724697702
+            },
+            "ma_boll_fixed": {
+              "return": -2.579,
+              "max_drawdown": 2.76,
+              "transactions": 2,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": -18.831581724697703
+            }
+          }
+        },
+        {
+          "fold": 8,
+          "test_start": "2025-06-06 00:00:00",
+          "test_end": "2025-07-05 00:00:00",
+          "market_return": 22.424444815495082,
+          "regime_counts": {
+            "BEAR": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -21.705354665680222
+            },
+            "buy_hold": {
+              "return": 21.705354665680222,
+              "max_drawdown": 27.76687824581649,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -21.705354665680222
+            },
+            "dual_ma_50_200": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -21.705354665680222
+            },
+            "volatility_target": {
+              "return": 17.466535281614924,
+              "max_drawdown": 11.361650052800245,
+              "transactions": 3,
+              "turnover": 1.1072875941851867,
+              "mean_exposure": 0.40553423408369677,
+              "excess_vs_buy_hold": -4.238819384065298
+            },
+            "regime_switch": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -21.705354665680222
+            },
+            "ma_boll_fixed": {
+              "return": -7.152,
+              "max_drawdown": 13.59,
+              "transactions": 5,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": -28.857354665680223
+            }
+          }
+        },
+        {
+          "fold": 9,
+          "test_start": "2025-07-06 00:00:00",
+          "test_end": "2025-08-04 00:00:00",
+          "market_return": 34.209108057127466,
+          "regime_counts": {
+            "BEAR": 4,
+            "RANGE": 26
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -33.00638259721731
+            },
+            "buy_hold": {
+              "return": 33.00638259721731,
+              "max_drawdown": 20.28220300409649,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 17.4943129159997,
+              "max_drawdown": 20.282203004096495,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 0.8666666666666667,
+              "excess_vs_buy_hold": -15.51206968121761
+            },
+            "dual_ma_50_200": {
+              "return": -3.683674350341004,
+              "max_drawdown": 20.2822030040965,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 0.36666666666666664,
+              "excess_vs_buy_hold": -36.69005694755832
+            },
+            "volatility_target": {
+              "return": 16.071647018433932,
+              "max_drawdown": 11.80316127611763,
+              "transactions": 1,
+              "turnover": 0.4869254293801013,
+              "mean_exposure": 0.5428492714936762,
+              "excess_vs_buy_hold": -16.93473557878338
+            },
+            "regime_switch": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -33.00638259721731
+            },
+            "ma_boll_fixed": {
+              "return": -4.996,
+              "max_drawdown": 16.89,
+              "transactions": 8,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": -38.00238259721731
+            }
+          }
+        },
+        {
+          "fold": 10,
+          "test_start": "2025-08-05 00:00:00",
+          "test_end": "2025-09-03 00:00:00",
+          "market_return": 0.9915457676651807,
+          "regime_counts": {
+            "RANGE": 25,
+            "BULL": 5
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 4.918127140349338
+            },
+            "buy_hold": {
+              "return": -4.918127140349338,
+              "max_drawdown": 22.91014014839241,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": -4.918127140349338,
+              "max_drawdown": 22.91014014839241,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "dual_ma_50_200": {
+              "return": -4.918127140349338,
+              "max_drawdown": 22.91014014839241,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "volatility_target": {
+              "return": -2.628272050404956,
+              "max_drawdown": 13.235750360813881,
+              "transactions": 1,
+              "turnover": 0.5344050642453035,
+              "mean_exposure": 0.5399550719712677,
+              "excess_vs_buy_hold": 2.2898550899443815
+            },
+            "regime_switch": {
+              "return": -1.6608845322641397,
+              "max_drawdown": 4.96392427255083,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 0.16666666666666666,
+              "excess_vs_buy_hold": 3.257242608085198
+            },
+            "ma_boll_fixed": {
+              "return": -9.944,
+              "max_drawdown": 13.77,
+              "transactions": 2,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": -5.025872859650663
+            }
+          }
+        },
+        {
+          "fold": 11,
+          "test_start": "2025-09-04 00:00:00",
+          "test_end": "2025-10-03 00:00:00",
+          "market_return": -11.972437553832904,
+          "regime_counts": {
+            "BULL": 26,
+            "RANGE": 4
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 17.283501865500405
+            },
+            "buy_hold": {
+              "return": -17.283501865500405,
+              "max_drawdown": 26.76097848511642,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": -30.82221588050771,
+              "max_drawdown": 32.824597827334486,
+              "transactions": 5,
+              "turnover": 5.0,
+              "mean_exposure": 0.8666666666666667,
+              "excess_vs_buy_hold": -13.538714015007304
+            },
+            "dual_ma_50_200": {
+              "return": -17.283501865500405,
+              "max_drawdown": 26.76097848511642,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "volatility_target": {
+              "return": -17.698924538136197,
+              "max_drawdown": 24.984040775338944,
+              "transactions": 4,
+              "turnover": 1.173440475684663,
+              "mean_exposure": 0.8000662639825249,
+              "excess_vs_buy_hold": -0.4154226726357919
+            },
+            "regime_switch": {
+              "return": -17.283501865500405,
+              "max_drawdown": 26.76097848511642,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "ma_boll_fixed": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": 17.283501865500405
+            }
+          }
+        },
+        {
+          "fold": 12,
+          "test_start": "2025-10-04 00:00:00",
+          "test_end": "2025-11-02 00:00:00",
+          "market_return": -26.990654205607477,
+          "regime_counts": {
+            "BULL": 6,
+            "RANGE": 24
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 29.842417856116477
+            },
+            "buy_hold": {
+              "return": -29.842417856116477,
+              "max_drawdown": 31.143610644929286,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": -37.40462578394076,
+              "max_drawdown": 37.33559228564448,
+              "transactions": 4,
+              "turnover": 4.0,
+              "mean_exposure": 0.2,
+              "excess_vs_buy_hold": -7.562207927824282
+            },
+            "dual_ma_50_200": {
+              "return": -23.647412826899117,
+              "max_drawdown": 30.56820906257493,
+              "transactions": 2,
+              "turnover": 2.0,
+              "mean_exposure": 0.8,
+              "excess_vs_buy_hold": 6.195005029217359
+            },
+            "volatility_target": {
+              "return": -23.38479552166326,
+              "max_drawdown": 23.901026365409813,
+              "transactions": 4,
+              "turnover": 1.3445850334893994,
+              "mean_exposure": 0.510658246752924,
+              "excess_vs_buy_hold": 6.457622334453216
+            },
+            "regime_switch": {
+              "return": -29.842417856116477,
+              "max_drawdown": 31.143610644929286,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "ma_boll_fixed": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": 29.842417856116477
+            }
+          }
+        },
+        {
+          "fold": 13,
+          "test_start": "2025-11-03 00:00:00",
+          "test_end": "2025-12-02 00:00:00",
+          "market_return": 13.88995767602923,
+          "regime_counts": {
+            "RANGE": 28,
+            "BULL": 2
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 1.078610756030085
+            },
+            "buy_hold": {
+              "return": -1.078610756030085,
+              "max_drawdown": 40.09842730287792,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": -22.4194106129165,
+              "max_drawdown": 22.419410612916497,
+              "transactions": 2,
+              "turnover": 2.0,
+              "mean_exposure": 0.06666666666666667,
+              "excess_vs_buy_hold": -21.340799856886417
+            },
+            "dual_ma_50_200": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 1.078610756030085
+            },
+            "volatility_target": {
+              "return": 12.72521757740317,
+              "max_drawdown": 14.211408065776402,
+              "transactions": 5,
+              "turnover": 1.9040865239200577,
+              "mean_exposure": 0.3440577054789996,
+              "excess_vs_buy_hold": 13.803828333433255
+            },
+            "regime_switch": {
+              "return": -1.078610756030085,
+              "max_drawdown": 40.09842730287792,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "ma_boll_fixed": {
+              "return": -6.351,
+              "max_drawdown": 8.92,
+              "transactions": 4,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": -5.272389243969915
+            }
+          }
+        },
+        {
+          "fold": 14,
+          "test_start": "2025-12-03 00:00:00",
+          "test_end": "2026-01-01 00:00:00",
+          "market_return": -4.879646307515961,
+          "regime_counts": {
+            "RANGE": 7,
+            "BEAR": 23
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 3.9173362538795664
+            },
+            "buy_hold": {
+              "return": -3.9173362538795664,
+              "max_drawdown": 18.781725888324885,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 3.9173362538795664
+            },
+            "dual_ma_50_200": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 3.9173362538795664
+            },
+            "volatility_target": {
+              "return": -0.6142368004711352,
+              "max_drawdown": 13.006029452096607,
+              "transactions": 3,
+              "turnover": 1.0100420454825942,
+              "mean_exposure": 0.5940151100650221,
+              "excess_vs_buy_hold": 3.3030994534084313
+            },
+            "regime_switch": {
+              "return": -6.953328111320989,
+              "max_drawdown": 10.57802521696414,
+              "transactions": 2,
+              "turnover": 2.0,
+              "mean_exposure": 0.23333333333333334,
+              "excess_vs_buy_hold": -3.0359918574414224
+            },
+            "ma_boll_fixed": {
+              "return": 4.093,
+              "max_drawdown": 4.279999999999999,
+              "transactions": 3,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": 8.010336253879567
+            }
+          }
+        },
+        {
+          "fold": 15,
+          "test_start": "2026-01-02 00:00:00",
+          "test_end": "2026-01-31 00:00:00",
+          "market_return": -34.41536932759192,
+          "regime_counts": {
+            "BEAR": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 33.24856961220597
+            },
+            "buy_hold": {
+              "return": -33.24856961220597,
+              "max_drawdown": 35.73515092502434,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 33.24856961220597
+            },
+            "dual_ma_50_200": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 33.24856961220597
+            },
+            "volatility_target": {
+              "return": -27.27519946800452,
+              "max_drawdown": 28.699068513670756,
+              "transactions": 6,
+              "turnover": 1.3372338134170851,
+              "mean_exposure": 0.7218508929920698,
+              "excess_vs_buy_hold": 5.97337014420145
+            },
+            "regime_switch": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 33.24856961220597
+            },
+            "ma_boll_fixed": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": 33.24856961220597
+            }
+          }
+        },
+        {
+          "fold": 16,
+          "test_start": "2026-02-01 00:00:00",
+          "test_end": "2026-03-02 00:00:00",
+          "market_return": 2.3977065415689225,
+          "regime_counts": {
+            "BEAR": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 2.8888304323800407
+            },
+            "buy_hold": {
+              "return": -2.8888304323800407,
+              "max_drawdown": 19.286624203821646,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 2.8888304323800407
+            },
+            "dual_ma_50_200": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 2.8888304323800407
+            },
+            "volatility_target": {
+              "return": -8.545348510598483,
+              "max_drawdown": 16.30276685279737,
+              "transactions": 4,
+              "turnover": 1.2346882659695466,
+              "mean_exposure": 0.5271261769296817,
+              "excess_vs_buy_hold": -5.6565180782184425
+            },
+            "regime_switch": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 2.8888304323800407
+            },
+            "ma_boll_fixed": {
+              "return": 1.301,
+              "max_drawdown": 0.0,
+              "transactions": 1,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": 4.189830432380041
+            }
+          }
+        },
+        {
+          "fold": 17,
+          "test_start": "2026-03-03 00:00:00",
+          "test_end": "2026-04-01 00:00:00",
+          "market_return": -8.819018404907975,
+          "regime_counts": {
+            "BEAR": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 11.11815138284975
+            },
+            "buy_hold": {
+              "return": -11.11815138284975,
+              "max_drawdown": 19.292759201347117,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 11.11815138284975
+            },
+            "dual_ma_50_200": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 11.11815138284975
+            },
+            "volatility_target": {
+              "return": -10.52882167256801,
+              "max_drawdown": 16.708252627369692,
+              "transactions": 2,
+              "turnover": 0.9232350174187114,
+              "mean_exposure": 0.6758132043774512,
+              "excess_vs_buy_hold": 0.5893297102817385
+            },
+            "regime_switch": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 11.11815138284975
+            },
+            "ma_boll_fixed": {
+              "return": -7.226,
+              "max_drawdown": 10.54,
+              "transactions": 6,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": 3.8921513828497494
+            }
+          }
+        },
+        {
+          "fold": 18,
+          "test_start": "2026-04-02 00:00:00",
+          "test_end": "2026-05-01 00:00:00",
+          "market_return": 0.945179584120992,
+          "regime_counts": {
+            "BEAR": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 12.061025601816166
+            },
+            "buy_hold": {
+              "return": -12.061025601816166,
+              "max_drawdown": 8.155812538040186,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 12.061025601816166
+            },
+            "dual_ma_50_200": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 12.061025601816166
+            },
+            "volatility_target": {
+              "return": -11.255314382437554,
+              "max_drawdown": 6.120945746017028,
+              "transactions": 3,
+              "turnover": 1.1601695016962177,
+              "mean_exposure": 0.7274799817541485,
+              "excess_vs_buy_hold": 0.8057112193786118
+            },
+            "regime_switch": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 12.061025601816166
+            },
+            "ma_boll_fixed": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": 12.061025601816166
+            }
+          }
+        },
+        {
+          "fold": 19,
+          "test_start": "2026-05-02 00:00:00",
+          "test_end": "2026-05-31 00:00:00",
+          "market_return": -7.096774193548383,
+          "regime_counts": {
+            "BEAR": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 7.569171384344642
+            },
+            "buy_hold": {
+              "return": -7.569171384344642,
+              "max_drawdown": 24.38657986980471,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 7.569171384344642
+            },
+            "dual_ma_50_200": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 7.569171384344642
+            },
+            "volatility_target": {
+              "return": -5.268351409997418,
+              "max_drawdown": 21.381965963419326,
+              "transactions": 3,
+              "turnover": 1.165652976696083,
+              "mean_exposure": 0.8895918827481288,
+              "excess_vs_buy_hold": 2.300819974347224
+            },
+            "regime_switch": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 7.569171384344642
+            },
+            "ma_boll_fixed": {
+              "return": -11.003,
+              "max_drawdown": 15.28,
+              "transactions": 7,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": -3.433828615655358
+            }
+          }
+        },
+        {
+          "fold": 20,
+          "test_start": "2026-06-01 00:00:00",
+          "test_end": "2026-06-30 00:00:00",
+          "market_return": -6.903485254691688,
+          "regime_counts": {
+            "BEAR": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 10.091891579494872
+            },
+            "buy_hold": {
+              "return": -10.091891579494872,
+              "max_drawdown": 19.70509383378017,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 10.091891579494872
+            },
+            "dual_ma_50_200": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 10.091891579494872
+            },
+            "volatility_target": {
+              "return": -9.040942067511025,
+              "max_drawdown": 19.469516560411275,
+              "transactions": 5,
+              "turnover": 1.6188367279927396,
+              "mean_exposure": 0.7158356493579101,
+              "excess_vs_buy_hold": 1.0509495119838466
+            },
+            "regime_switch": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 10.091891579494872
+            },
+            "ma_boll_fixed": {
+              "return": -4.428,
+              "max_drawdown": 4.43,
+              "transactions": 1,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": 5.663891579494872
+            }
+          }
+        },
+        {
+          "fold": 21,
+          "test_start": "2026-07-01 00:00:00",
+          "test_end": "2026-07-30 00:00:00",
+          "market_return": 58.94585873072784,
+          "regime_counts": {
+            "BEAR": 21,
+            "RANGE": 9
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -56.17128463476071
+            },
+            "buy_hold": {
+              "return": 56.17128463476071,
+              "max_drawdown": 4.726432057539162,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 16.66666666666665,
+              "max_drawdown": 4.726432057539156,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 0.3,
+              "excess_vs_buy_hold": -39.50461796809406
+            },
+            "dual_ma_50_200": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -56.17128463476071
+            },
+            "volatility_target": {
+              "return": 38.63802041079425,
+              "max_drawdown": 4.726432057539171,
+              "transactions": 5,
+              "turnover": 1.2752952210184465,
+              "mean_exposure": 0.7641493948209824,
+              "excess_vs_buy_hold": -17.533264223966462
+            },
+            "regime_switch": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -56.17128463476071
+            },
+            "ma_boll_fixed": {
+              "return": 3.446,
+              "max_drawdown": 3.81,
+              "transactions": 10,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": -52.72528463476071
+            }
+          }
+        }
+      ],
+      "summary": {
+        "cash": {
+          "continuous_oos_return": 0.0,
+          "continuous_excess_vs_buy_hold": 51.24143354679249,
+          "fold_compounded_return": 0.0,
+          "mean_fold_return": 0.0,
+          "median_fold_return": 0.0,
+          "mean_excess_vs_buy_hold": 1.2251085150716994,
+          "excess_win_rate": 0.7619047619047619,
+          "continuous_transactions": 0,
+          "continuous_turnover": 0.0,
+          "continuous_max_drawdown": 0.0,
+          "mean_fold_max_drawdown": 0.0
+        },
+        "buy_hold": {
+          "continuous_oos_return": -51.24143354679249,
+          "continuous_excess_vs_buy_hold": 0.0,
+          "fold_compounded_return": -68.12743099832336,
+          "mean_fold_return": -1.2251085150716994,
+          "median_fold_return": -7.569171384344642,
+          "mean_excess_vs_buy_hold": 0.0,
+          "excess_win_rate": 0.0,
+          "continuous_transactions": 1,
+          "continuous_turnover": 1.0,
+          "continuous_max_drawdown": 87.11897209827428,
+          "mean_fold_max_drawdown": 23.936457480168222
+        },
+        "sma200_trend": {
+          "continuous_oos_return": -65.4515500178074,
+          "continuous_excess_vs_buy_hold": -14.210116471014913,
+          "fold_compounded_return": -68.93916253111033,
+          "mean_fold_return": -2.112318418463824,
+          "median_fold_return": 0.0,
+          "mean_excess_vs_buy_hold": -0.8872099033921248,
+          "excess_win_rate": 0.47619047619047616,
+          "continuous_transactions": 19,
+          "continuous_turnover": 19.0,
+          "continuous_max_drawdown": 86.01999230282958,
+          "mean_fold_max_drawdown": 11.730625657526724
+        },
+        "dual_ma_50_200": {
+          "continuous_oos_return": -54.9474351088737,
+          "continuous_excess_vs_buy_hold": -3.7060015620812052,
+          "fold_compounded_return": -61.177087698440744,
+          "mean_fold_return": -2.2699831038681335,
+          "median_fold_return": 0.0,
+          "mean_excess_vs_buy_hold": -1.0448745887964346,
+          "excess_win_rate": 0.5238095238095238,
+          "continuous_transactions": 4,
+          "continuous_turnover": 4.0,
+          "continuous_max_drawdown": 78.88279831127208,
+          "mean_fold_max_drawdown": 10.07344599835718
+        },
+        "volatility_target": {
+          "continuous_oos_return": -41.11693587442565,
+          "continuous_excess_vs_buy_hold": 10.124497672366843,
+          "fold_compounded_return": -55.3808037564965,
+          "mean_fold_return": -2.1990799824825165,
+          "median_fold_return": -5.268351409997418,
+          "mean_excess_vs_buy_hold": -0.9739714674108169,
+          "excess_win_rate": 0.6190476190476191,
+          "continuous_transactions": 65,
+          "continuous_turnover": 11.469803061544834,
+          "continuous_max_drawdown": 74.06332972963526,
+          "mean_fold_max_drawdown": 15.423495519693518
+        },
+        "regime_switch": {
+          "continuous_oos_return": -65.81690108549606,
+          "continuous_excess_vs_buy_hold": -14.575467538703563,
+          "fold_compounded_return": -70.53843029319215,
+          "mean_fold_return": -2.5438253408280724,
+          "median_fold_return": 0.0,
+          "mean_excess_vs_buy_hold": -1.318716825756373,
+          "excess_win_rate": 0.42857142857142855,
+          "continuous_transactions": 4,
+          "continuous_turnover": 4.0,
+          "continuous_max_drawdown": 86.155061667191,
+          "mean_fold_max_drawdown": 11.912483502077341
+        },
+        "ma_boll_fixed": {
+          "continuous_oos_return": -42.897,
+          "continuous_excess_vs_buy_hold": 8.344433546792494,
+          "fold_compounded_return": -44.39977117822526,
+          "mean_fold_return": -2.540809523809524,
+          "median_fold_return": 0.0,
+          "mean_excess_vs_buy_hold": -1.3157010087378251,
+          "excess_win_rate": 0.5714285714285714,
+          "continuous_transactions": 143,
+          "continuous_turnover": null,
+          "continuous_max_drawdown": 54.50000000000001,
+          "mean_fold_max_drawdown": 5.980952380952381
+        }
+      }
+    },
+    {
+      "symbol": "LTC",
+      "data_start": "2023-08-04 00:00:00",
+      "data_end": "2026-08-02 00:00:00",
+      "data_rows": 1095,
+      "folds": [
+        {
+          "fold": 1,
+          "test_start": "2024-11-08 00:00:00",
+          "test_end": "2024-12-07 00:00:00",
+          "market_return": 83.82797471832919,
+          "regime_counts": {
+            "BEAR": 1,
+            "RANGE": 17,
+            "BULL": 12
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -83.29585332104227
+            },
+            "buy_hold": {
+              "return": 83.29585332104227,
+              "max_drawdown": 12.617899811360303,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 79.94671903175814,
+              "max_drawdown": 12.617899811360308,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 0.9666666666666667,
+              "excess_vs_buy_hold": -3.3491342892841374
+            },
+            "dual_ma_50_200": {
+              "return": 51.12866826262468,
+              "max_drawdown": 7.276381909547728,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 0.6,
+              "excess_vs_buy_hold": -32.167185058417594
+            },
+            "volatility_target": {
+              "return": 44.91753646972509,
+              "max_drawdown": 7.495231306426647,
+              "transactions": 5,
+              "turnover": 1.424565196976848,
+              "mean_exposure": 0.604923643285577,
+              "excess_vs_buy_hold": -38.37831685131718
+            },
+            "regime_switch": {
+              "return": 42.01801667918985,
+              "max_drawdown": 1.9375775508256279,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 0.4,
+              "excess_vs_buy_hold": -41.277836641852424
+            },
+            "ma_boll_fixed": {
+              "return": 27.459,
+              "max_drawdown": 1.8800000000000001,
+              "transactions": 13,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": -55.83685332104227
+            }
+          }
+        },
+        {
+          "fold": 2,
+          "test_start": "2024-12-08 00:00:00",
+          "test_end": "2025-01-06 00:00:00",
+          "market_return": -15.4918093543844,
+          "regime_counts": {
+            "BULL": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 16.572104179548663
+            },
+            "buy_hold": {
+              "return": -16.572104179548663,
+              "max_drawdown": 26.980950263138386,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": -16.572104179548663,
+              "max_drawdown": 26.980950263138386,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "dual_ma_50_200": {
+              "return": -16.572104179548663,
+              "max_drawdown": 26.980950263138386,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "volatility_target": {
+              "return": -6.524180292306703,
+              "max_drawdown": 12.751796702021737,
+              "transactions": 2,
+              "turnover": 0.5938059534782363,
+              "mean_exposure": 0.45307835533144747,
+              "excess_vs_buy_hold": 10.04792388724196
+            },
+            "regime_switch": {
+              "return": -16.572104179548663,
+              "max_drawdown": 26.980950263138386,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "ma_boll_fixed": {
+              "return": 5.656,
+              "max_drawdown": 0.61,
+              "transactions": 3,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": 22.228104179548662
+            }
+          }
+        },
+        {
+          "fold": 3,
+          "test_start": "2025-01-07 00:00:00",
+          "test_end": "2025-02-05 00:00:00",
+          "market_return": 0.6425233644859807,
+          "regime_counts": {
+            "BULL": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 11.218255428781742
+            },
+            "buy_hold": {
+              "return": -11.218255428781742,
+              "max_drawdown": 26.2478108581436,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": -11.218255428781742,
+              "max_drawdown": 26.2478108581436,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "dual_ma_50_200": {
+              "return": -11.218255428781742,
+              "max_drawdown": 26.2478108581436,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "volatility_target": {
+              "return": -3.0290339220557905,
+              "max_drawdown": 14.08652554378608,
+              "transactions": 4,
+              "turnover": 0.9460209910428249,
+              "mean_exposure": 0.5228980177501501,
+              "excess_vs_buy_hold": 8.189221506725952
+            },
+            "regime_switch": {
+              "return": -11.218255428781742,
+              "max_drawdown": 26.2478108581436,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "ma_boll_fixed": {
+              "return": -12.527,
+              "max_drawdown": 20.91,
+              "transactions": 5,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": -1.3087445712182575
+            }
+          }
+        },
+        {
+          "fold": 4,
+          "test_start": "2025-02-06 00:00:00",
+          "test_end": "2025-03-07 00:00:00",
+          "market_return": 2.016525673814673,
+          "regime_counts": {
+            "BULL": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 1.7853881463863908
+            },
+            "buy_hold": {
+              "return": -1.7853881463863908,
+              "max_drawdown": 23.346678529062867,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": -1.7853881463863908,
+              "max_drawdown": 23.346678529062867,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "dual_ma_50_200": {
+              "return": -1.7853881463863908,
+              "max_drawdown": 23.346678529062867,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "volatility_target": {
+              "return": -0.2851082355251,
+              "max_drawdown": 12.42288427591924,
+              "transactions": 5,
+              "turnover": 0.8831251401747138,
+              "mean_exposure": 0.5087849389319559,
+              "excess_vs_buy_hold": 1.5002799108612908
+            },
+            "regime_switch": {
+              "return": -1.7853881463863908,
+              "max_drawdown": 23.346678529062867,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "ma_boll_fixed": {
+              "return": -11.036,
+              "max_drawdown": 13.370000000000001,
+              "transactions": 4,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": -9.25061185361361
+            }
+          }
+        },
+        {
+          "fold": 5,
+          "test_start": "2025-03-08 00:00:00",
+          "test_end": "2025-04-06 00:00:00",
+          "market_return": -30.994723470783658,
+          "regime_counts": {
+            "BULL": 3,
+            "RANGE": 27
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 33.33481675975166
+            },
+            "buy_hold": {
+              "return": -33.33481675975166,
+              "max_drawdown": 30.994723470783665,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": -19.14230730796539,
+              "max_drawdown": 16.304025991792077,
+              "transactions": 2,
+              "turnover": 2.0,
+              "mean_exposure": 0.1,
+              "excess_vs_buy_hold": 14.192509451786272
+            },
+            "dual_ma_50_200": {
+              "return": -33.33481675975166,
+              "max_drawdown": 30.994723470783665,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "volatility_target": {
+              "return": -27.610163607277805,
+              "max_drawdown": 26.380760145480526,
+              "transactions": 4,
+              "turnover": 1.0445431180949507,
+              "mean_exposure": 0.6820100955918511,
+              "excess_vs_buy_hold": 5.724653152473856
+            },
+            "regime_switch": {
+              "return": -33.33481675975166,
+              "max_drawdown": 30.994723470783665,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "ma_boll_fixed": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": 33.33481675975166
+            }
+          }
+        },
+        {
+          "fold": 6,
+          "test_start": "2025-04-07 00:00:00",
+          "test_end": "2025-05-06 00:00:00",
+          "market_return": 29.032258064516125,
+          "regime_counts": {
+            "RANGE": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -26.969165621296455
+            },
+            "buy_hold": {
+              "return": 26.969165621296455,
+              "max_drawdown": 6.302757456387168,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -26.969165621296455
+            },
+            "dual_ma_50_200": {
+              "return": 3.3932839410341975,
+              "max_drawdown": 2.919900039458116,
+              "transactions": 2,
+              "turnover": 2.0,
+              "mean_exposure": 0.16666666666666666,
+              "excess_vs_buy_hold": -23.575881680262256
+            },
+            "volatility_target": {
+              "return": 17.169401124446825,
+              "max_drawdown": 6.302757456387162,
+              "transactions": 4,
+              "turnover": 1.1703642513157118,
+              "mean_exposure": 0.7243170430439152,
+              "excess_vs_buy_hold": -9.79976449684963
+            },
+            "regime_switch": {
+              "return": 17.099441806954218,
+              "max_drawdown": 5.456626812515903,
+              "transactions": 2,
+              "turnover": 2.0,
+              "mean_exposure": 0.6333333333333333,
+              "excess_vs_buy_hold": -9.869723814342237
+            },
+            "ma_boll_fixed": {
+              "return": 1.738,
+              "max_drawdown": 3.2300000000000004,
+              "transactions": 3,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": -25.231165621296455
+            }
+          }
+        },
+        {
+          "fold": 7,
+          "test_start": "2025-05-07 00:00:00",
+          "test_end": "2025-06-05 00:00:00",
+          "market_return": -6.645817044566071,
+          "regime_counts": {
+            "RANGE": 23,
+            "BULL": 7
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 10.669679665312836
+            },
+            "buy_hold": {
+              "return": -10.669679665312836,
+              "max_drawdown": 20.604160729552568,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": -11.700274856251557,
+              "max_drawdown": 13.877781139838266,
+              "transactions": 4,
+              "turnover": 4.0,
+              "mean_exposure": 0.23333333333333334,
+              "excess_vs_buy_hold": -1.0305951909387208
+            },
+            "dual_ma_50_200": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 10.669679665312836
+            },
+            "volatility_target": {
+              "return": -9.176980129062084,
+              "max_drawdown": 17.123871240759364,
+              "transactions": 3,
+              "turnover": 1.0933443116118153,
+              "mean_exposure": 0.773182258112766,
+              "excess_vs_buy_hold": 1.4926995362507522
+            },
+            "regime_switch": {
+              "return": -18.596723610651168,
+              "max_drawdown": 20.604160729552575,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 0.9,
+              "excess_vs_buy_hold": -7.9270439453383315
+            },
+            "ma_boll_fixed": {
+              "return": -13.908,
+              "max_drawdown": 13.91,
+              "transactions": 2,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": -3.238320334687163
+            }
+          }
+        },
+        {
+          "fold": 8,
+          "test_start": "2025-06-06 00:00:00",
+          "test_end": "2025-07-05 00:00:00",
+          "market_return": 0.3438395415472639,
+          "regime_counts": {
+            "RANGE": 12,
+            "BEAR": 18
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -2.5523889845497916
+            },
+            "buy_hold": {
+              "return": 2.5523889845497916,
+              "max_drawdown": 14.057644915889856,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -2.5523889845497916
+            },
+            "dual_ma_50_200": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -2.5523889845497916
+            },
+            "volatility_target": {
+              "return": 1.8153966245967768,
+              "max_drawdown": 13.083093305128719,
+              "transactions": 4,
+              "turnover": 1.24505484414189,
+              "mean_exposure": 0.911828158958669,
+              "excess_vs_buy_hold": -0.7369923599530148
+            },
+            "regime_switch": {
+              "return": -3.4064792493938123,
+              "max_drawdown": 11.643785920925742,
+              "transactions": 2,
+              "turnover": 2.0,
+              "mean_exposure": 0.4,
+              "excess_vs_buy_hold": -5.958868233943604
+            },
+            "ma_boll_fixed": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": -2.5523889845497916
+            }
+          }
+        },
+        {
+          "fold": 9,
+          "test_start": "2025-07-06 00:00:00",
+          "test_end": "2025-08-04 00:00:00",
+          "market_return": 38.775042930738415,
+          "regime_counts": {
+            "BEAR": 12,
+            "RANGE": 12,
+            "BULL": 6
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -35.553310196371335
+            },
+            "buy_hold": {
+              "return": 35.553310196371335,
+              "max_drawdown": 11.333054743000426,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 16.80799515445186,
+              "max_drawdown": 11.333054743000417,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 0.6,
+              "excess_vs_buy_hold": -18.745315041919476
+            },
+            "dual_ma_50_200": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -35.553310196371335
+            },
+            "volatility_target": {
+              "return": 33.335424674779055,
+              "max_drawdown": 9.309912160785082,
+              "transactions": 2,
+              "turnover": 1.190085249232406,
+              "mean_exposure": 0.8996321040201555,
+              "excess_vs_buy_hold": -2.2178855215922795
+            },
+            "regime_switch": {
+              "return": 9.359494173353378,
+              "max_drawdown": 4.290144061614738,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 0.2,
+              "excess_vs_buy_hold": -26.19381602301796
+            },
+            "ma_boll_fixed": {
+              "return": 4.538,
+              "max_drawdown": 7.12,
+              "transactions": 9,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": -31.015310196371335
+            }
+          }
+        },
+        {
+          "fold": 10,
+          "test_start": "2025-08-05 00:00:00",
+          "test_end": "2025-09-03 00:00:00",
+          "market_return": -6.061361935644793,
+          "regime_counts": {
+            "BULL": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 8.752854141403876
+            },
+            "buy_hold": {
+              "return": -8.752854141403876,
+              "max_drawdown": 16.9429378962646,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": -8.752854141403876,
+              "max_drawdown": 16.9429378962646,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "dual_ma_50_200": {
+              "return": -7.222118596049132,
+              "max_drawdown": 16.942937896264613,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 0.9333333333333333,
+              "excess_vs_buy_hold": 1.5307355453547444
+            },
+            "volatility_target": {
+              "return": -6.252324176515978,
+              "max_drawdown": 12.327423751561014,
+              "transactions": 4,
+              "turnover": 1.024787630735111,
+              "mean_exposure": 0.6748452172960838,
+              "excess_vs_buy_hold": 2.5005299648878987
+            },
+            "regime_switch": {
+              "return": -8.752854141403876,
+              "max_drawdown": 16.9429378962646,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "ma_boll_fixed": {
+              "return": -1.949,
+              "max_drawdown": 7.57,
+              "transactions": 5,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": 6.8038541414038765
+            }
+          }
+        },
+        {
+          "fold": 11,
+          "test_start": "2025-09-04 00:00:00",
+          "test_end": "2025-10-03 00:00:00",
+          "market_return": 8.563710040522299,
+          "regime_counts": {
+            "RANGE": 25,
+            "BULL": 5
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -4.4704985225431315
+            },
+            "buy_hold": {
+              "return": 4.4704985225431315,
+              "max_drawdown": 14.20902533132025,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 4.4704985225431315,
+              "max_drawdown": 14.20902533132025,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "dual_ma_50_200": {
+              "return": 4.4704985225431315,
+              "max_drawdown": 14.20902533132025,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "volatility_target": {
+              "return": 3.9360731768861124,
+              "max_drawdown": 13.54220116159891,
+              "transactions": 2,
+              "turnover": 0.9513598393933176,
+              "mean_exposure": 0.9168038405742127,
+              "excess_vs_buy_hold": -0.5344253456570192
+            },
+            "regime_switch": {
+              "return": 12.983686328125742,
+              "max_drawdown": 7.218011698693114,
+              "transactions": 3,
+              "turnover": 3.0,
+              "mean_exposure": 0.7,
+              "excess_vs_buy_hold": 8.51318780558261
+            },
+            "ma_boll_fixed": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": -4.4704985225431315
+            }
+          }
+        },
+        {
+          "fold": 12,
+          "test_start": "2025-10-04 00:00:00",
+          "test_end": "2025-11-02 00:00:00",
+          "market_return": -17.50062235499129,
+          "regime_counts": {
+            "BULL": 9,
+            "RANGE": 21
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 19.27157192148483
+            },
+            "buy_hold": {
+              "return": -19.27157192148483,
+              "max_drawdown": 28.41938046068309,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": -30.65964424050136,
+              "max_drawdown": 32.17222074032944,
+              "transactions": 5,
+              "turnover": 5.0,
+              "mean_exposure": 0.3,
+              "excess_vs_buy_hold": -11.38807231901653
+            },
+            "dual_ma_50_200": {
+              "return": -19.27157192148483,
+              "max_drawdown": 28.41938046068309,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "volatility_target": {
+              "return": -16.619104071923886,
+              "max_drawdown": 23.318350369205543,
+              "transactions": 3,
+              "turnover": 1.8135971552622252,
+              "mean_exposure": 0.590186947780801,
+              "excess_vs_buy_hold": 2.6524678495609457
+            },
+            "regime_switch": {
+              "return": -19.27157192148483,
+              "max_drawdown": 28.41938046068309,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "ma_boll_fixed": {
+              "return": -4.673,
+              "max_drawdown": 4.73,
+              "transactions": 10,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": 14.598571921484831
+            }
+          }
+        },
+        {
+          "fold": 13,
+          "test_start": "2025-11-03 00:00:00",
+          "test_end": "2025-12-02 00:00:00",
+          "market_return": -5.307102825117238,
+          "regime_counts": {
+            "RANGE": 24,
+            "BULL": 4,
+            "BEAR": 2
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 18.474002360544294
+            },
+            "buy_hold": {
+              "return": -18.474002360544294,
+              "max_drawdown": 29.69812347022029,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": -6.212227383923496,
+              "max_drawdown": 11.523430514005993,
+              "transactions": 2,
+              "turnover": 2.0,
+              "mean_exposure": 0.13333333333333341,
+              "excess_vs_buy_hold": 12.261774976620798
+            },
+            "dual_ma_50_200": {
+              "return": -5.906500500103407,
+              "max_drawdown": 13.37834103889041,
+              "transactions": 2,
+              "turnover": 2.0,
+              "mean_exposure": 0.3333333333333334,
+              "excess_vs_buy_hold": 12.567501860440887
+            },
+            "volatility_target": {
+              "return": -14.965416436268097,
+              "max_drawdown": 18.930476171625905,
+              "transactions": 5,
+              "turnover": 1.8878514570825113,
+              "mean_exposure": 0.5634711966846252,
+              "excess_vs_buy_hold": 3.508585924276197
+            },
+            "regime_switch": {
+              "return": -20.589328342146686,
+              "max_drawdown": 26.89522491161272,
+              "transactions": 2,
+              "turnover": 2.0,
+              "mean_exposure": 0.9333333333333333,
+              "excess_vs_buy_hold": -2.1153259816023926
+            },
+            "ma_boll_fixed": {
+              "return": -9.002,
+              "max_drawdown": 9.64,
+              "transactions": 3,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": 9.472002360544293
+            }
+          }
+        },
+        {
+          "fold": 14,
+          "test_start": "2025-12-03 00:00:00",
+          "test_end": "2026-01-01 00:00:00",
+          "market_return": -6.827449609693581,
+          "regime_counts": {
+            "BEAR": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 5.444072835377178
+            },
+            "buy_hold": {
+              "return": -5.444072835377178,
+              "max_drawdown": 13.445182337178133,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 5.444072835377178
+            },
+            "dual_ma_50_200": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 5.444072835377178
+            },
+            "volatility_target": {
+              "return": -4.658110935464976,
+              "max_drawdown": 11.564006284356253,
+              "transactions": 3,
+              "turnover": 1.0125879308044397,
+              "mean_exposure": 0.8622531458118387,
+              "excess_vs_buy_hold": 0.785961899912202
+            },
+            "regime_switch": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 5.444072835377178
+            },
+            "ma_boll_fixed": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": 5.444072835377178
+            }
+          }
+        },
+        {
+          "fold": 15,
+          "test_start": "2026-01-02 00:00:00",
+          "test_end": "2026-01-31 00:00:00",
+          "market_return": -27.340412547296477,
+          "regime_counts": {
+            "BEAR": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 27.12127187555472
+            },
+            "buy_hold": {
+              "return": -27.12127187555472,
+              "max_drawdown": 29.097189137684605,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 27.12127187555472
+            },
+            "dual_ma_50_200": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 27.12127187555472
+            },
+            "volatility_target": {
+              "return": -27.12127187555472,
+              "max_drawdown": 29.097189137684605,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "regime_switch": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 27.12127187555472
+            },
+            "ma_boll_fixed": {
+              "return": -18.425,
+              "max_drawdown": 18.43,
+              "transactions": 5,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": 8.696271875554718
+            }
+          }
+        },
+        {
+          "fold": 16,
+          "test_start": "2026-02-01 00:00:00",
+          "test_end": "2026-03-02 00:00:00",
+          "market_return": -6.633612583347581,
+          "regime_counts": {
+            "BEAR": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 10.189256401250347
+            },
+            "buy_hold": {
+              "return": -10.189256401250347,
+              "max_drawdown": 15.378207264245258,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 10.189256401250347
+            },
+            "dual_ma_50_200": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 10.189256401250347
+            },
+            "volatility_target": {
+              "return": -10.023035708131234,
+              "max_drawdown": 12.503083346757125,
+              "transactions": 4,
+              "turnover": 1.1567947138562755,
+              "mean_exposure": 0.6457437287907845,
+              "excess_vs_buy_hold": 0.16622069311911325
+            },
+            "regime_switch": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 10.189256401250347
+            },
+            "ma_boll_fixed": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": 10.189256401250347
+            }
+          }
+        },
+        {
+          "fold": 17,
+          "test_start": "2026-03-03 00:00:00",
+          "test_end": "2026-04-01 00:00:00",
+          "market_return": -1.7165814463111717,
+          "regime_counts": {
+            "BEAR": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 3.5141748930432315
+            },
+            "buy_hold": {
+              "return": -3.5141748930432315,
+              "max_drawdown": 9.16524701873936,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 3.5141748930432315
+            },
+            "dual_ma_50_200": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 3.5141748930432315
+            },
+            "volatility_target": {
+              "return": -4.690090566712001,
+              "max_drawdown": 9.35503285329045,
+              "transactions": 2,
+              "turnover": 0.9935039197935209,
+              "mean_exposure": 0.8973062188615223,
+              "excess_vs_buy_hold": -1.17591567366877
+            },
+            "regime_switch": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 3.5141748930432315
+            },
+            "ma_boll_fixed": {
+              "return": -7.517,
+              "max_drawdown": 8.32,
+              "transactions": 4,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": -4.002825106956768
+            }
+          }
+        },
+        {
+          "fold": 18,
+          "test_start": "2026-04-02 00:00:00",
+          "test_end": "2026-05-01 00:00:00",
+          "market_return": 5.947599923503533,
+          "regime_counts": {
+            "BEAR": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -0.7762211775589556
+            },
+            "buy_hold": {
+              "return": 0.7762211775589556,
+              "max_drawdown": 4.131938286930311,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -0.7762211775589556
+            },
+            "dual_ma_50_200": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -0.7762211775589556
+            },
+            "volatility_target": {
+              "return": 0.7762211775589556,
+              "max_drawdown": 4.131938286930311,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "regime_switch": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -0.7762211775589556
+            },
+            "ma_boll_fixed": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": -0.7762211775589556
+            }
+          }
+        },
+        {
+          "fold": 19,
+          "test_start": "2026-05-02 00:00:00",
+          "test_end": "2026-05-31 00:00:00",
+          "market_return": -5.993861707889514,
+          "regime_counts": {
+            "BEAR": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 7.98263108732421
+            },
+            "buy_hold": {
+              "return": -7.98263108732421,
+              "max_drawdown": 14.496111203044856,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 7.98263108732421
+            },
+            "dual_ma_50_200": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 7.98263108732421
+            },
+            "volatility_target": {
+              "return": -7.98263108732421,
+              "max_drawdown": 14.496111203044856,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "regime_switch": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 7.98263108732421
+            },
+            "ma_boll_fixed": {
+              "return": -12.434,
+              "max_drawdown": 13.01,
+              "transactions": 3,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": -4.45136891267579
+            }
+          }
+        },
+        {
+          "fold": 20,
+          "test_start": "2026-06-01 00:00:00",
+          "test_end": "2026-06-30 00:00:00",
+          "market_return": -17.444378814727312,
+          "regime_counts": {
+            "BEAR": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 21.17828408150988
+            },
+            "buy_hold": {
+              "return": -21.17828408150988,
+              "max_drawdown": 19.43295924394565,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 21.17828408150988
+            },
+            "dual_ma_50_200": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 21.17828408150988
+            },
+            "volatility_target": {
+              "return": -21.17828408150988,
+              "max_drawdown": 19.43295924394565,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "regime_switch": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 21.17828408150988
+            },
+            "ma_boll_fixed": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": 21.17828408150988
+            }
+          }
+        },
+        {
+          "fold": 21,
+          "test_start": "2026-07-01 00:00:00",
+          "test_end": "2026-07-30 00:00:00",
+          "market_return": 6.719737766331058,
+          "regime_counts": {
+            "BEAR": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -6.39908493985748
+            },
+            "buy_hold": {
+              "return": 6.39908493985748,
+              "max_drawdown": 4.9958193979933085,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -6.39908493985748
+            },
+            "dual_ma_50_200": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -6.39908493985748
+            },
+            "volatility_target": {
+              "return": 6.39908493985748,
+              "max_drawdown": 4.9958193979933085,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "regime_switch": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -6.39908493985748
+            },
+            "ma_boll_fixed": {
+              "return": -5.052,
+              "max_drawdown": 5.27,
+              "transactions": 4,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": -11.45108493985748
+            }
+          }
+        }
+      ],
+      "summary": {
+        "cash": {
+          "continuous_oos_return": 0.0,
+          "continuous_excess_vs_buy_hold": 37.5541894433582,
+          "fold_compounded_return": 0.0,
+          "mean_fold_return": 0.0,
+          "median_fold_return": 0.0,
+          "mean_excess_vs_buy_hold": 1.6900876673359255,
+          "excess_win_rate": 0.6666666666666666,
+          "continuous_transactions": 0,
+          "continuous_turnover": 0.0,
+          "continuous_max_drawdown": 0.0,
+          "mean_fold_max_drawdown": 0.0
+        },
+        "buy_hold": {
+          "continuous_oos_return": -37.5541894433582,
+          "continuous_excess_vs_buy_hold": 0.0,
+          "fold_compounded_return": -59.16388338432981,
+          "mean_fold_return": -1.6900876673359255,
+          "median_fold_return": -7.98263108732421,
+          "mean_excess_vs_buy_hold": 0.0,
+          "excess_win_rate": 0.0,
+          "continuous_transactions": 1,
+          "continuous_turnover": 1.0,
+          "continuous_max_drawdown": 70.1401050788091,
+          "mean_fold_max_drawdown": 17.709419134550885
+        },
+        "sma200_trend": {
+          "continuous_oos_return": -23.140241550299066,
+          "continuous_excess_vs_buy_hold": 14.413947893059131,
+          "fold_compounded_return": -32.321065691725245,
+          "mean_fold_return": -0.2294210940956833,
+          "median_fold_return": 0.0,
+          "mean_excess_vs_buy_hold": 1.4606665732402424,
+          "excess_win_rate": 0.38095238095238093,
+          "continuous_transactions": 14,
+          "continuous_turnover": 14.0,
+          "continuous_max_drawdown": 58.30044825753775,
+          "mean_fold_max_drawdown": 9.788372181821725
+        },
+        "dual_ma_50_200": {
+          "continuous_oos_return": -33.885456830472,
+          "continuous_excess_vs_buy_hold": 3.6687326128861955,
+          "fold_compounded_return": -44.20778972334652,
+          "mean_fold_return": -1.72944308599542,
+          "median_fold_return": 0.0,
+          "mean_excess_vs_buy_hold": -0.039355418659494316,
+          "excess_win_rate": 0.42857142857142855,
+          "continuous_transactions": 4,
+          "continuous_turnover": 4.0,
+          "continuous_max_drawdown": 61.91309930622244,
+          "mean_fold_max_drawdown": 9.08172046653775
+        },
+        "volatility_target": {
+          "continuous_oos_return": -37.86597437564314,
+          "continuous_excess_vs_buy_hold": -0.31178493228494375,
+          "fold_compounded_return": -56.144580582086576,
+          "mean_fold_return": -2.4650760446562936,
+          "median_fold_return": -4.690090566712001,
+          "mean_excess_vs_buy_hold": -0.7749883773203678,
+          "excess_win_rate": 0.47619047619047616,
+          "continuous_transactions": 50,
+          "continuous_turnover": 8.981665198933243,
+          "continuous_max_drawdown": 66.15530130696456,
+          "mean_fold_max_drawdown": 13.935782064032786
+        },
+        "regime_switch": {
+          "continuous_oos_return": -43.33242583537482,
+          "continuous_excess_vs_buy_hold": -5.778236392016623,
+          "fold_compounded_return": -54.16521658253347,
+          "mean_fold_return": -2.4793753710440782,
+          "median_fold_return": 0.0,
+          "mean_excess_vs_buy_hold": -0.7892877037081528,
+          "excess_win_rate": 0.3333333333333333,
+          "continuous_transactions": 8,
+          "continuous_turnover": 8.0,
+          "continuous_max_drawdown": 61.04461668000567,
+          "mean_fold_max_drawdown": 10.998953007800791
+        },
+        "ma_boll_fixed": {
+          "continuous_oos_return": -44.038,
+          "continuous_excess_vs_buy_hold": -6.483810556641799,
+          "fold_compounded_return": -48.80667956397643,
+          "mean_fold_return": -2.7205714285714286,
+          "median_fold_return": 0.0,
+          "mean_excess_vs_buy_hold": -1.030483761235503,
+          "excess_win_rate": 0.42857142857142855,
+          "continuous_transactions": 116,
+          "continuous_turnover": null,
+          "continuous_max_drawdown": 60.99,
+          "mean_fold_max_drawdown": 6.095238095238096
+        }
+      }
+    },
+    {
+      "symbol": "ETC",
+      "data_start": "2023-08-04 00:00:00",
+      "data_end": "2026-08-02 00:00:00",
+      "data_rows": 1095,
+      "folds": [
+        {
+          "fold": 1,
+          "test_start": "2024-11-08 00:00:00",
+          "test_end": "2024-12-07 00:00:00",
+          "market_return": 81.9070904645477,
+          "regime_counts": {
+            "BEAR": 5,
+            "RANGE": 17,
+            "BULL": 8
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -79.7610089811472
+            },
+            "buy_hold": {
+              "return": 79.7610089811472,
+              "max_drawdown": 10.545752974969217,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 45.70089704972682,
+              "max_drawdown": 11.297654493229391,
+              "transactions": 3,
+              "turnover": 3.0,
+              "mean_exposure": 0.8333333333333334,
+              "excess_vs_buy_hold": -34.06011193142038
+            },
+            "dual_ma_50_200": {
+              "return": 11.37486366844167,
+              "max_drawdown": 5.543766578249354,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 0.23333333333333334,
+              "excess_vs_buy_hold": -68.38614531270554
+            },
+            "volatility_target": {
+              "return": 45.59163885765252,
+              "max_drawdown": 8.505288779789403,
+              "transactions": 4,
+              "turnover": 1.438505146983508,
+              "mean_exposure": 0.590193480945329,
+              "excess_vs_buy_hold": -34.16937012349468
+            },
+            "regime_switch": {
+              "return": 14.060696584968447,
+              "max_drawdown": 5.543766578249354,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 0.26666666666666666,
+              "excess_vs_buy_hold": -65.70031239617876
+            },
+            "ma_boll_fixed": {
+              "return": 10.771,
+              "max_drawdown": 3.8899999999999997,
+              "transactions": 12,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": -68.9900089811472
+            }
+          }
+        },
+        {
+          "fold": 2,
+          "test_start": "2024-12-08 00:00:00",
+          "test_end": "2025-01-06 00:00:00",
+          "market_return": -22.680690399136992,
+          "regime_counts": {
+            "BULL": 29,
+            "RANGE": 1
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 24.546958417926156
+            },
+            "buy_hold": {
+              "return": -24.546958417926156,
+              "max_drawdown": 32.41639697950377,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": -24.546958417926156,
+              "max_drawdown": 32.41639697950377,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "dual_ma_50_200": {
+              "return": -24.546958417926156,
+              "max_drawdown": 32.41639697950377,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "volatility_target": {
+              "return": -9.700614503386662,
+              "max_drawdown": 16.407292030513283,
+              "transactions": 3,
+              "turnover": 0.7729740288014845,
+              "mean_exposure": 0.49294158309294106,
+              "excess_vs_buy_hold": 14.846343914539494
+            },
+            "regime_switch": {
+              "return": -24.546958417926156,
+              "max_drawdown": 32.41639697950377,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "ma_boll_fixed": {
+              "return": -15.221,
+              "max_drawdown": 11.21,
+              "transactions": 5,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": 9.325958417926156
+            }
+          }
+        },
+        {
+          "fold": 3,
+          "test_start": "2025-01-07 00:00:00",
+          "test_end": "2025-02-05 00:00:00",
+          "market_return": -20.115830115830104,
+          "regime_counts": {
+            "BULL": 27,
+            "RANGE": 3
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 29.347945392591367
+            },
+            "buy_hold": {
+              "return": -29.347945392591367,
+              "max_drawdown": 28.80771881461061,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": -24.77912391062026,
+              "max_drawdown": 24.093900758097877,
+              "transactions": 2,
+              "turnover": 2.0,
+              "mean_exposure": 0.9,
+              "excess_vs_buy_hold": 4.568821481971106
+            },
+            "dual_ma_50_200": {
+              "return": -29.347945392591367,
+              "max_drawdown": 28.80771881461061,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "volatility_target": {
+              "return": -17.228881905538707,
+              "max_drawdown": 17.821549208790035,
+              "transactions": 3,
+              "turnover": 0.8260109550970228,
+              "mean_exposure": 0.6340487869801551,
+              "excess_vs_buy_hold": 12.11906348705266
+            },
+            "regime_switch": {
+              "return": -29.347945392591367,
+              "max_drawdown": 28.80771881461061,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "ma_boll_fixed": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": 29.347945392591367
+            }
+          }
+        },
+        {
+          "fold": 4,
+          "test_start": "2025-02-06 00:00:00",
+          "test_end": "2025-03-07 00:00:00",
+          "market_return": 3.6566785170137006,
+          "regime_counts": {
+            "RANGE": 14,
+            "BEAR": 16
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 3.469477382520836
+            },
+            "buy_hold": {
+              "return": -3.469477382520836,
+              "max_drawdown": 12.8564749883123,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 3.469477382520836
+            },
+            "dual_ma_50_200": {
+              "return": -11.791955001520204,
+              "max_drawdown": 12.8564749883123,
+              "transactions": 2,
+              "turnover": 2.0,
+              "mean_exposure": 0.8,
+              "excess_vs_buy_hold": -8.322477618999368
+            },
+            "volatility_target": {
+              "return": -4.187106509696337,
+              "max_drawdown": 11.058742329020331,
+              "transactions": 5,
+              "turnover": 1.1384368695498002,
+              "mean_exposure": 0.6681188043936089,
+              "excess_vs_buy_hold": -0.7176291271755009
+            },
+            "regime_switch": {
+              "return": -0.9569510489510269,
+              "max_drawdown": 2.2243713733075476,
+              "transactions": 2,
+              "turnover": 2.0,
+              "mean_exposure": 0.3,
+              "excess_vs_buy_hold": 2.512526333569809
+            },
+            "ma_boll_fixed": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": 3.469477382520836
+            }
+          }
+        },
+        {
+          "fold": 5,
+          "test_start": "2025-03-08 00:00:00",
+          "test_end": "2025-04-06 00:00:00",
+          "market_return": -30.00494315373208,
+          "regime_counts": {
+            "RANGE": 6,
+            "BEAR": 24
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 32.044426162073215
+            },
+            "buy_hold": {
+              "return": -32.044426162073215,
+              "max_drawdown": 30.00494315373208,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 32.044426162073215
+            },
+            "dual_ma_50_200": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 32.044426162073215
+            },
+            "volatility_target": {
+              "return": -24.628392652482933,
+              "max_drawdown": 23.459147324601435,
+              "transactions": 3,
+              "turnover": 0.9975044834715644,
+              "mean_exposure": 0.6386728116199282,
+              "excess_vs_buy_hold": 7.416033509590282
+            },
+            "regime_switch": {
+              "return": 1.6398816822987383,
+              "max_drawdown": 2.533604004449406,
+              "transactions": 2,
+              "turnover": 2.0,
+              "mean_exposure": 0.1,
+              "excess_vs_buy_hold": 33.68430784437195
+            },
+            "ma_boll_fixed": {
+              "return": -8.937,
+              "max_drawdown": 7.46,
+              "transactions": 1,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": 23.107426162073217
+            }
+          }
+        },
+        {
+          "fold": 6,
+          "test_start": "2025-04-07 00:00:00",
+          "test_end": "2025-05-06 00:00:00",
+          "market_return": 12.008281573498959,
+          "regime_counts": {
+            "BEAR": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -12.214057129311362
+            },
+            "buy_hold": {
+              "return": 12.214057129311362,
+              "max_drawdown": 7.192575406032467,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -12.214057129311362
+            },
+            "dual_ma_50_200": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -12.214057129311362
+            },
+            "volatility_target": {
+              "return": 7.273392878989204,
+              "max_drawdown": 7.176037934827913,
+              "transactions": 4,
+              "turnover": 1.2052167360770007,
+              "mean_exposure": 0.8082740507479498,
+              "excess_vs_buy_hold": -4.940664250322158
+            },
+            "regime_switch": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -12.214057129311362
+            },
+            "ma_boll_fixed": {
+              "return": -5.564,
+              "max_drawdown": 6.7299999999999995,
+              "transactions": 3,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": -17.778057129311364
+            }
+          }
+        },
+        {
+          "fold": 7,
+          "test_start": "2025-05-07 00:00:00",
+          "test_end": "2025-06-05 00:00:00",
+          "market_return": 0.6176652254477943,
+          "regime_counts": {
+            "BEAR": 27,
+            "RANGE": 3
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 1.7964793826862668
+            },
+            "buy_hold": {
+              "return": -1.7964793826862668,
+              "max_drawdown": 21.304347826086946,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 1.7964793826862668
+            },
+            "dual_ma_50_200": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 1.7964793826862668
+            },
+            "volatility_target": {
+              "return": -1.0669775371838108,
+              "max_drawdown": 17.16203256418844,
+              "transactions": 5,
+              "turnover": 1.712558915916408,
+              "mean_exposure": 0.7240198816974395,
+              "excess_vs_buy_hold": 0.729501845502456
+            },
+            "regime_switch": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 1.7964793826862668
+            },
+            "ma_boll_fixed": {
+              "return": -9.889,
+              "max_drawdown": 9.89,
+              "transactions": 1,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": -8.092520617313733
+            }
+          }
+        },
+        {
+          "fold": 8,
+          "test_start": "2025-06-06 00:00:00",
+          "test_end": "2025-07-05 00:00:00",
+          "market_return": -1.9760479041916024,
+          "regime_counts": {
+            "BEAR": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 1.6171060369955192
+            },
+            "buy_hold": {
+              "return": -1.6171060369955192,
+              "max_drawdown": 18.157327586206883,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 1.6171060369955192
+            },
+            "dual_ma_50_200": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 1.6171060369955192
+            },
+            "volatility_target": {
+              "return": -2.353917552162199,
+              "max_drawdown": 16.57367614036943,
+              "transactions": 3,
+              "turnover": 1.1572992120593422,
+              "mean_exposure": 0.8698304306749548,
+              "excess_vs_buy_hold": -0.7368115151666799
+            },
+            "regime_switch": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 1.6171060369955192
+            },
+            "ma_boll_fixed": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": 1.6171060369955192
+            }
+          }
+        },
+        {
+          "fold": 9,
+          "test_start": "2025-07-06 00:00:00",
+          "test_end": "2025-08-04 00:00:00",
+          "market_return": 26.141826923076916,
+          "regime_counts": {
+            "BEAR": 11,
+            "RANGE": 19
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -25.53237843402778
+            },
+            "buy_hold": {
+              "return": 25.53237843402778,
+              "max_drawdown": 22.276225192385578,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 3.368462523392113,
+              "max_drawdown": 22.276225192385578,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 0.6333333333333333,
+              "excess_vs_buy_hold": -22.163915910635666
+            },
+            "dual_ma_50_200": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -25.53237843402778
+            },
+            "volatility_target": {
+              "return": 26.189246690633293,
+              "max_drawdown": 15.11883560363253,
+              "transactions": 3,
+              "turnover": 1.3034562201915487,
+              "mean_exposure": 0.7573579792810604,
+              "excess_vs_buy_hold": 0.6568682566055131
+            },
+            "regime_switch": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -25.53237843402778
+            },
+            "ma_boll_fixed": {
+              "return": -5.109,
+              "max_drawdown": 8.85,
+              "transactions": 8,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": -30.64137843402778
+            }
+          }
+        },
+        {
+          "fold": 10,
+          "test_start": "2025-08-05 00:00:00",
+          "test_end": "2025-09-03 00:00:00",
+          "market_return": 3.221010901883048,
+          "regime_counts": {
+            "RANGE": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 2.844178213401649
+            },
+            "buy_hold": {
+              "return": -2.844178213401649,
+              "max_drawdown": 16.28571428571429,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": -2.844178213401649,
+              "max_drawdown": 16.28571428571429,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "dual_ma_50_200": {
+              "return": 1.055535148696718,
+              "max_drawdown": 16.28571428571429,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 0.9666666666666667,
+              "excess_vs_buy_hold": 3.899713362098367
+            },
+            "volatility_target": {
+              "return": 0.15295826153665093,
+              "max_drawdown": 10.769750473605342,
+              "transactions": 4,
+              "turnover": 0.9718817695687589,
+              "mean_exposure": 0.5669633754168024,
+              "excess_vs_buy_hold": 2.9971364749383
+            },
+            "regime_switch": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 2.844178213401649
+            },
+            "ma_boll_fixed": {
+              "return": -6.106,
+              "max_drawdown": 6.78,
+              "transactions": 1,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": -3.2618217865983508
+            }
+          }
+        },
+        {
+          "fold": 11,
+          "test_start": "2025-09-04 00:00:00",
+          "test_end": "2025-10-03 00:00:00",
+          "market_return": -1.189296333002965,
+          "regime_counts": {
+            "RANGE": 11,
+            "BULL": 19
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 6.325919761620313
+            },
+            "buy_hold": {
+              "return": -6.325919761620313,
+              "max_drawdown": 18.902991840435167,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": -14.665407633675054,
+              "max_drawdown": 17.65725767299175,
+              "transactions": 3,
+              "turnover": 3.0,
+              "mean_exposure": 0.7666666666666667,
+              "excess_vs_buy_hold": -8.33948787205474
+            },
+            "dual_ma_50_200": {
+              "return": -6.325919761620313,
+              "max_drawdown": 18.902991840435167,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "volatility_target": {
+              "return": -7.121772513920188,
+              "max_drawdown": 18.092185894863658,
+              "transactions": 2,
+              "turnover": 0.9546176039368566,
+              "mean_exposure": 0.8400218395263593,
+              "excess_vs_buy_hold": -0.7958527522998748
+            },
+            "regime_switch": {
+              "return": -4.679305069930074,
+              "max_drawdown": 18.90299184043517,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 0.8666666666666667,
+              "excess_vs_buy_hold": 1.6466146916902398
+            },
+            "ma_boll_fixed": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": 6.325919761620313
+            }
+          }
+        },
+        {
+          "fold": 12,
+          "test_start": "2025-10-04 00:00:00",
+          "test_end": "2025-11-02 00:00:00",
+          "market_return": -15.835475578406166,
+          "regime_counts": {
+            "BULL": 7,
+            "RANGE": 13,
+            "BEAR": 10
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 19.66629861366702
+            },
+            "buy_hold": {
+              "return": -19.66629861366702,
+              "max_drawdown": 28.02802802802803,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": -30.912488774383494,
+              "max_drawdown": 29.537999999999993,
+              "transactions": 2,
+              "turnover": 2.0,
+              "mean_exposure": 0.23333333333333334,
+              "excess_vs_buy_hold": -11.246190160716473
+            },
+            "dual_ma_50_200": {
+              "return": -23.129333824070653,
+              "max_drawdown": 28.02802802802803,
+              "transactions": 2,
+              "turnover": 2.0,
+              "mean_exposure": 0.7,
+              "excess_vs_buy_hold": -3.463035210403632
+            },
+            "volatility_target": {
+              "return": -23.70185654012551,
+              "max_drawdown": 26.31657894221156,
+              "transactions": 4,
+              "turnover": 1.949159611336758,
+              "mean_exposure": 0.605728614301278,
+              "excess_vs_buy_hold": -4.035557926458491
+            },
+            "regime_switch": {
+              "return": -24.61870298122928,
+              "max_drawdown": 28.02802802802803,
+              "transactions": 2,
+              "turnover": 2.0,
+              "mean_exposure": 0.6,
+              "excess_vs_buy_hold": -4.952404367562259
+            },
+            "ma_boll_fixed": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": 19.66629861366702
+            }
+          }
+        },
+        {
+          "fold": 13,
+          "test_start": "2025-11-03 00:00:00",
+          "test_end": "2025-12-02 00:00:00",
+          "market_return": -9.460359760159898,
+          "regime_counts": {
+            "RANGE": 12,
+            "BEAR": 18
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 18.723915058673768
+            },
+            "buy_hold": {
+              "return": -18.723915058673768,
+              "max_drawdown": 27.5823562255723,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 18.723915058673768
+            },
+            "dual_ma_50_200": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 18.723915058673768
+            },
+            "volatility_target": {
+              "return": -9.50509878543706,
+              "max_drawdown": 17.756463450105876,
+              "transactions": 5,
+              "turnover": 2.188964768477201,
+              "mean_exposure": 0.5803076971791317,
+              "excess_vs_buy_hold": 9.218816273236708
+            },
+            "regime_switch": {
+              "return": 14.35407223934524,
+              "max_drawdown": 6.986488877301109,
+              "transactions": 2,
+              "turnover": 2.0,
+              "mean_exposure": 0.13333333333333333,
+              "excess_vs_buy_hold": 33.07798729801901
+            },
+            "ma_boll_fixed": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": 18.723915058673768
+            }
+          }
+        },
+        {
+          "fold": 14,
+          "test_start": "2025-12-03 00:00:00",
+          "test_end": "2026-01-01 00:00:00",
+          "market_return": -15.010570824524304,
+          "regime_counts": {
+            "BEAR": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 13.119992590191254
+            },
+            "buy_hold": {
+              "return": -13.119992590191254,
+              "max_drawdown": 19.097956307258624,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 13.119992590191254
+            },
+            "dual_ma_50_200": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 13.119992590191254
+            },
+            "volatility_target": {
+              "return": -12.418904797639229,
+              "max_drawdown": 17.9155270166252,
+              "transactions": 3,
+              "turnover": 1.2527089129828095,
+              "mean_exposure": 0.8937377507902762,
+              "excess_vs_buy_hold": 0.7010877925520251
+            },
+            "regime_switch": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 13.119992590191254
+            },
+            "ma_boll_fixed": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": 13.119992590191254
+            }
+          }
+        },
+        {
+          "fold": 15,
+          "test_start": "2026-01-02 00:00:00",
+          "test_end": "2026-01-31 00:00:00",
+          "market_return": -22.04472843450479,
+          "regime_counts": {
+            "BEAR": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 20.834757620176003
+            },
+            "buy_hold": {
+              "return": -20.834757620176003,
+              "max_drawdown": 27.000747943156313,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 20.834757620176003
+            },
+            "dual_ma_50_200": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 20.834757620176003
+            },
+            "volatility_target": {
+              "return": -18.750372208957845,
+              "max_drawdown": 24.30840089489828,
+              "transactions": 4,
+              "turnover": 1.2538443000653792,
+              "mean_exposure": 0.8940334934175629,
+              "excess_vs_buy_hold": 2.0843854112181575
+            },
+            "regime_switch": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 20.834757620176003
+            },
+            "ma_boll_fixed": {
+              "return": -17.801,
+              "max_drawdown": 15.32,
+              "transactions": 2,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": 3.0337576201760044
+            }
+          }
+        },
+        {
+          "fold": 16,
+          "test_start": "2026-02-01 00:00:00",
+          "test_end": "2026-03-02 00:00:00",
+          "market_return": -8.210526315789469,
+          "regime_counts": {
+            "BEAR": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 12.619621933849135
+            },
+            "buy_hold": {
+              "return": -12.619621933849135,
+              "max_drawdown": 17.83893985728849,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 12.619621933849135
+            },
+            "dual_ma_50_200": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 12.619621933849135
+            },
+            "volatility_target": {
+              "return": -13.609915354040492,
+              "max_drawdown": 16.303428976073153,
+              "transactions": 5,
+              "turnover": 1.3573248652377081,
+              "mean_exposure": 0.6284859468815572,
+              "excess_vs_buy_hold": -0.9902934201913567
+            },
+            "regime_switch": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 12.619621933849135
+            },
+            "ma_boll_fixed": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": 12.619621933849135
+            }
+          }
+        },
+        {
+          "fold": 17,
+          "test_start": "2026-03-03 00:00:00",
+          "test_end": "2026-04-01 00:00:00",
+          "market_return": -3.5335689045936425,
+          "regime_counts": {
+            "BEAR": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 8.04837364470391
+            },
+            "buy_hold": {
+              "return": -8.04837364470391,
+              "max_drawdown": 11.960132890365427,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 8.04837364470391
+            },
+            "dual_ma_50_200": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 8.04837364470391
+            },
+            "volatility_target": {
+              "return": -6.77425053889883,
+              "max_drawdown": 10.621491706606983,
+              "transactions": 4,
+              "turnover": 1.0341611623698,
+              "mean_exposure": 0.7794513228227489,
+              "excess_vs_buy_hold": 1.2741231058050797
+            },
+            "regime_switch": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 8.04837364470391
+            },
+            "ma_boll_fixed": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": 8.04837364470391
+            }
+          }
+        },
+        {
+          "fold": 18,
+          "test_start": "2026-04-02 00:00:00",
+          "test_end": "2026-05-01 00:00:00",
+          "market_return": 6.725888324873108,
+          "regime_counts": {
+            "BEAR": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -0.4093467508101911
+            },
+            "buy_hold": {
+              "return": 0.4093467508101911,
+              "max_drawdown": 8.239277652370191,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -0.4093467508101911
+            },
+            "dual_ma_50_200": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -0.4093467508101911
+            },
+            "volatility_target": {
+              "return": 0.09026026245007035,
+              "max_drawdown": 7.137829903420144,
+              "transactions": 2,
+              "turnover": 0.9997945436952372,
+              "mean_exposure": 0.8793034063719107,
+              "excess_vs_buy_hold": -0.31908648836012077
+            },
+            "regime_switch": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -0.4093467508101911
+            },
+            "ma_boll_fixed": {
+              "return": 0.637,
+              "max_drawdown": 3.2199999999999998,
+              "transactions": 1,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": 0.2276532491898089
+            }
+          }
+        },
+        {
+          "fold": 19,
+          "test_start": "2026-05-02 00:00:00",
+          "test_end": "2026-05-31 00:00:00",
+          "market_return": -4.1031652989449,
+          "regime_counts": {
+            "BEAR": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 4.775367319957091
+            },
+            "buy_hold": {
+              "return": -4.775367319957091,
+              "max_drawdown": 18.036072144288585,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 4.775367319957091
+            },
+            "dual_ma_50_200": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 4.775367319957091
+            },
+            "volatility_target": {
+              "return": -4.775367319957091,
+              "max_drawdown": 18.036072144288585,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "regime_switch": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 4.775367319957091
+            },
+            "ma_boll_fixed": {
+              "return": -8.322,
+              "max_drawdown": 9.959999999999999,
+              "transactions": 4,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": -3.546632680042908
+            }
+          }
+        },
+        {
+          "fold": 20,
+          "test_start": "2026-06-01 00:00:00",
+          "test_end": "2026-06-30 00:00:00",
+          "market_return": -14.833127317676142,
+          "regime_counts": {
+            "BEAR": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 17.5372304956657
+            },
+            "buy_hold": {
+              "return": -17.5372304956657,
+              "max_drawdown": 16.06922126081582,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 17.5372304956657
+            },
+            "dual_ma_50_200": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 17.5372304956657
+            },
+            "volatility_target": {
+              "return": -16.99929050064589,
+              "max_drawdown": 16.06922126081582,
+              "transactions": 3,
+              "turnover": 1.318951772030311,
+              "mean_exposure": 0.9733574079064219,
+              "excess_vs_buy_hold": 0.5379399950198085
+            },
+            "regime_switch": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 17.5372304956657
+            },
+            "ma_boll_fixed": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": 17.5372304956657
+            }
+          }
+        },
+        {
+          "fold": 21,
+          "test_start": "2026-07-01 00:00:00",
+          "test_end": "2026-07-30 00:00:00",
+          "market_return": -3.4236804564907297,
+          "regime_counts": {
+            "BEAR": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 3.803018461944452
+            },
+            "buy_hold": {
+              "return": -3.803018461944452,
+              "max_drawdown": 9.641873278236918,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 3.803018461944452
+            },
+            "dual_ma_50_200": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 3.803018461944452
+            },
+            "volatility_target": {
+              "return": -3.803018461944452,
+              "max_drawdown": 9.641873278236918,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "regime_switch": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 3.803018461944452
+            },
+            "ma_boll_fixed": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": 3.803018461944452
+            }
+          }
+        }
+      ],
+      "summary": {
+        "cash": {
+          "continuous_oos_return": 0.0,
+          "continuous_excess_vs_buy_hold": 67.28542927950627,
+          "fold_compounded_return": 0.0,
+          "mean_fold_return": 0.0,
+          "median_fold_return": 0.0,
+          "mean_excess_vs_buy_hold": 4.9144892949212915,
+          "excess_win_rate": 0.8095238095238095,
+          "continuous_transactions": 0,
+          "continuous_turnover": 0.0,
+          "continuous_max_drawdown": 0.0,
+          "mean_fold_max_drawdown": 0.0
+        },
+        "buy_hold": {
+          "continuous_oos_return": -67.28542927950627,
+          "continuous_excess_vs_buy_hold": 0.0,
+          "fold_compounded_return": -78.69135579902415,
+          "mean_fold_return": -4.9144892949212915,
+          "median_fold_return": -6.325919761620313,
+          "mean_excess_vs_buy_hold": 0.0,
+          "excess_win_rate": 0.0,
+          "continuous_transactions": 1,
+          "continuous_turnover": 1.0,
+          "continuous_max_drawdown": 82.85863600731643,
+          "mean_fold_max_drawdown": 19.154527363589047
+        },
+        "sma200_trend": {
+          "continuous_oos_return": -45.508957516400486,
+          "continuous_excess_vs_buy_hold": 21.77647176310579,
+          "fold_compounded_return": -51.03802622641944,
+          "mean_fold_return": -2.318037970327985,
+          "median_fold_return": 0.0,
+          "mean_excess_vs_buy_hold": 2.596451324593307,
+          "excess_win_rate": 0.6190476190476191,
+          "continuous_transactions": 8,
+          "continuous_turnover": 8.0,
+          "continuous_max_drawdown": 63.64640466535235,
+          "mean_fold_max_drawdown": 7.312626161043935
+        },
+        "dual_ma_50_200": {
+          "continuous_oos_return": -57.56607813460381,
+          "continuous_excess_vs_buy_hold": 9.719351144902461,
+          "fold_compounded_return": -61.89016065993578,
+          "mean_fold_return": -3.9386530276471574,
+          "median_fold_return": 0.0,
+          "mean_excess_vs_buy_hold": 0.9758362672741338,
+          "excess_win_rate": 0.5714285714285714,
+          "continuous_transactions": 4,
+          "continuous_turnover": 4.0,
+          "continuous_max_drawdown": 66.00165285034961,
+          "mean_fold_max_drawdown": 6.801956738802549
+        },
+        "volatility_target": {
+          "continuous_oos_return": -59.25419795334703,
+          "continuous_excess_vs_buy_hold": 8.031231326159244,
+          "fold_compounded_return": -71.2144891916291,
+          "mean_fold_return": -4.634678130035976,
+          "median_fold_return": -6.77425053889883,
+          "mean_excess_vs_buy_hold": 0.2798111648853153,
+          "excess_win_rate": 0.5238095238095238,
+          "continuous_transactions": 51,
+          "continuous_turnover": 9.732856079515184,
+          "continuous_max_drawdown": 73.16949593412399,
+          "mean_fold_max_drawdown": 15.53578218368973
+        },
+        "regime_switch": {
+          "continuous_oos_return": -45.19909038597872,
+          "continuous_excess_vs_buy_hold": 22.086338893527554,
+          "fold_compounded_return": -49.704612419832195,
+          "mean_fold_return": -2.5759624954293083,
+          "median_fold_return": 0.0,
+          "mean_excess_vs_buy_hold": 2.3385267994919827,
+          "excess_win_rate": 0.6666666666666666,
+          "continuous_transactions": 8,
+          "continuous_turnover": 8.0,
+          "continuous_max_drawdown": 62.013382025243246,
+          "mean_fold_max_drawdown": 5.97349364266119
+        },
+        "ma_boll_fixed": {
+          "continuous_oos_return": -30.11,
+          "continuous_excess_vs_buy_hold": 37.175429279506275,
+          "fold_compounded_return": -50.827314964307504,
+          "mean_fold_return": -3.121,
+          "median_fold_return": 0.0,
+          "mean_excess_vs_buy_hold": 1.7934892949212917,
+          "excess_win_rate": 0.7142857142857143,
+          "continuous_transactions": 84,
+          "continuous_turnover": null,
+          "continuous_max_drawdown": 39.28,
+          "mean_fold_max_drawdown": 3.967142857142857
+        }
+      }
+    },
+    {
+      "symbol": "DOGE",
+      "data_start": "2023-08-04 00:00:00",
+      "data_end": "2026-08-02 00:00:00",
+      "data_rows": 1095,
+      "folds": [
+        {
+          "fold": 1,
+          "test_start": "2024-11-08 00:00:00",
+          "test_end": "2024-12-07 00:00:00",
+          "market_return": 124.19666287072334,
+          "regime_counts": {
+            "RANGE": 4,
+            "BULL": 26
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -129.3974072499299
+            },
+            "buy_hold": {
+              "return": 129.3974072499299,
+              "max_drawdown": 10.036492108871998,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 129.3974072499299,
+              "max_drawdown": 10.036492108871998,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "dual_ma_50_200": {
+              "return": 129.3974072499299,
+              "max_drawdown": 10.036492108871998,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "volatility_target": {
+              "return": 38.99558819868814,
+              "max_drawdown": 4.691307600630408,
+              "transactions": 5,
+              "turnover": 1.0888315153602943,
+              "mean_exposure": 0.3803536860222303,
+              "excess_vs_buy_hold": -90.40181905124176
+            },
+            "regime_switch": {
+              "return": 26.173470758642225,
+              "max_drawdown": 10.03649210887199,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 0.8666666666666667,
+              "excess_vs_buy_hold": -103.22393649128767
+            },
+            "ma_boll_fixed": {
+              "return": 3.823,
+              "max_drawdown": 3.0300000000000002,
+              "transactions": 5,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": -125.5744072499299
+            }
+          }
+        },
+        {
+          "fold": 2,
+          "test_start": "2024-12-08 00:00:00",
+          "test_end": "2025-01-06 00:00:00",
+          "market_return": -16.839283799721237,
+          "regime_counts": {
+            "BULL": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 16.15310026192698
+            },
+            "buy_hold": {
+              "return": -16.15310026192698,
+              "max_drawdown": 33.12747936099495,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": -16.15310026192698,
+              "max_drawdown": 33.12747936099495,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "dual_ma_50_200": {
+              "return": -16.15310026192698,
+              "max_drawdown": 33.12747936099495,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "volatility_target": {
+              "return": -10.44056597241262,
+              "max_drawdown": 21.41376081732713,
+              "transactions": 2,
+              "turnover": 0.744739348492592,
+              "mean_exposure": 0.5772401131473919,
+              "excess_vs_buy_hold": 5.712534289514361
+            },
+            "regime_switch": {
+              "return": -16.15310026192698,
+              "max_drawdown": 33.12747936099495,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "ma_boll_fixed": {
+              "return": -14.469,
+              "max_drawdown": 9.39,
+              "transactions": 6,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": 1.6841002619269805
+            }
+          }
+        },
+        {
+          "fold": 3,
+          "test_start": "2025-01-07 00:00:00",
+          "test_end": "2025-02-05 00:00:00",
+          "market_return": -26.382183908045974,
+          "regime_counts": {
+            "BULL": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 35.326856630554225
+            },
+            "buy_hold": {
+              "return": -35.326856630554225,
+              "max_drawdown": 38.30463576158941,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": -35.326856630554225,
+              "max_drawdown": 38.30463576158941,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "dual_ma_50_200": {
+              "return": -35.326856630554225,
+              "max_drawdown": 38.30463576158941,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "volatility_target": {
+              "return": -18.31428653937258,
+              "max_drawdown": 21.743889863785533,
+              "transactions": 4,
+              "turnover": 0.8466423674003378,
+              "mean_exposure": 0.5178123583694815,
+              "excess_vs_buy_hold": 17.012570091181644
+            },
+            "regime_switch": {
+              "return": -35.326856630554225,
+              "max_drawdown": 38.30463576158941,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "ma_boll_fixed": {
+              "return": -15.48,
+              "max_drawdown": 18.72,
+              "transactions": 6,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": 19.846856630554225
+            }
+          }
+        },
+        {
+          "fold": 4,
+          "test_start": "2025-02-06 00:00:00",
+          "test_end": "2025-03-07 00:00:00",
+          "market_return": -19.94836419379563,
+          "regime_counts": {
+            "BULL": 19,
+            "RANGE": 11
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 24.160938799655273
+            },
+            "buy_hold": {
+              "return": -24.160938799655273,
+              "max_drawdown": 26.990434142752022,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": -21.262143632219754,
+              "max_drawdown": 24.199790728476835,
+              "transactions": 2,
+              "turnover": 2.0,
+              "mean_exposure": 0.6333333333333333,
+              "excess_vs_buy_hold": 2.8987951674355195
+            },
+            "dual_ma_50_200": {
+              "return": -24.160938799655273,
+              "max_drawdown": 26.990434142752022,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "volatility_target": {
+              "return": -14.216182656103914,
+              "max_drawdown": 19.255568882731726,
+              "transactions": 4,
+              "turnover": 1.0709901492201743,
+              "mean_exposure": 0.6028364078086308,
+              "excess_vs_buy_hold": 9.94475614355136
+            },
+            "regime_switch": {
+              "return": -24.160938799655273,
+              "max_drawdown": 26.990434142752022,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "ma_boll_fixed": {
+              "return": -11.128,
+              "max_drawdown": 11.129999999999999,
+              "transactions": 4,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": 13.032938799655273
+            }
+          }
+        },
+        {
+          "fold": 5,
+          "test_start": "2025-03-08 00:00:00",
+          "test_end": "2025-04-06 00:00:00",
+          "market_return": -22.39263803680981,
+          "regime_counts": {
+            "RANGE": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 26.352637434631067
+            },
+            "buy_hold": {
+              "return": -26.352637434631067,
+              "max_drawdown": 23.41200615700357,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 26.352637434631067
+            },
+            "dual_ma_50_200": {
+              "return": -16.947415420843804,
+              "max_drawdown": 19.891858167827806,
+              "transactions": 2,
+              "turnover": 2.0,
+              "mean_exposure": 0.23333333333333334,
+              "excess_vs_buy_hold": 9.405222013787263
+            },
+            "volatility_target": {
+              "return": -14.991598147701657,
+              "max_drawdown": 15.015069579453943,
+              "transactions": 3,
+              "turnover": 0.7237105456850879,
+              "mean_exposure": 0.48334728880329275,
+              "excess_vs_buy_hold": 11.36103928692941
+            },
+            "regime_switch": {
+              "return": -26.352637434631067,
+              "max_drawdown": 23.41200615700357,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "ma_boll_fixed": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": 26.352637434631067
+            }
+          }
+        },
+        {
+          "fold": 6,
+          "test_start": "2025-04-07 00:00:00",
+          "test_end": "2025-05-06 00:00:00",
+          "market_return": 15.115657173418917,
+          "regime_counts": {
+            "RANGE": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -12.934697111021908
+            },
+            "buy_hold": {
+              "return": 12.934697111021908,
+              "max_drawdown": 8.393485652926099,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -12.934697111021908
+            },
+            "dual_ma_50_200": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -12.934697111021908
+            },
+            "volatility_target": {
+              "return": 5.556290815803111,
+              "max_drawdown": 4.657363863811597,
+              "transactions": 4,
+              "turnover": 0.933229236625096,
+              "mean_exposure": 0.5630844676687938,
+              "excess_vs_buy_hold": -7.378406295218797
+            },
+            "regime_switch": {
+              "return": 14.706951883783127,
+              "max_drawdown": 8.393485652926099,
+              "transactions": 2,
+              "turnover": 2.0,
+              "mean_exposure": 0.5333333333333333,
+              "excess_vs_buy_hold": 1.7722547727612188
+            },
+            "ma_boll_fixed": {
+              "return": -3.865,
+              "max_drawdown": 4.569999999999999,
+              "transactions": 2,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": -16.799697111021906
+            }
+          }
+        },
+        {
+          "fold": 7,
+          "test_start": "2025-05-07 00:00:00",
+          "test_end": "2025-06-05 00:00:00",
+          "market_return": -0.5638879200092983,
+          "regime_counts": {
+            "RANGE": 28,
+            "BEAR": 2
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 2.7517198248905306
+            },
+            "buy_hold": {
+              "return": -2.7517198248905306,
+              "max_drawdown": 31.751984997805526,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 2.7517198248905306
+            },
+            "dual_ma_50_200": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 2.7517198248905306
+            },
+            "volatility_target": {
+              "return": 5.822695977239567,
+              "max_drawdown": 16.33419593540681,
+              "transactions": 4,
+              "turnover": 1.514945084729914,
+              "mean_exposure": 0.4688624314478119,
+              "excess_vs_buy_hold": 8.574415802130098
+            },
+            "regime_switch": {
+              "return": -4.384601267107701,
+              "max_drawdown": 4.3846012671077,
+              "transactions": 2,
+              "turnover": 2.0,
+              "mean_exposure": 0.13333333333333333,
+              "excess_vs_buy_hold": -1.6328814422171707
+            },
+            "ma_boll_fixed": {
+              "return": -8.377,
+              "max_drawdown": 12.57,
+              "transactions": 4,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": -5.62528017510947
+            }
+          }
+        },
+        {
+          "fold": 8,
+          "test_start": "2025-06-06 00:00:00",
+          "test_end": "2025-07-05 00:00:00",
+          "market_return": -8.149681172390643,
+          "regime_counts": {
+            "BEAR": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 6.018335692134347
+            },
+            "buy_hold": {
+              "return": -6.018335692134347,
+              "max_drawdown": 23.78337531486146,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 6.018335692134347
+            },
+            "dual_ma_50_200": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 6.018335692134347
+            },
+            "volatility_target": {
+              "return": -5.120128305144423,
+              "max_drawdown": 17.574518434046414,
+              "transactions": 4,
+              "turnover": 1.0813707377343333,
+              "mean_exposure": 0.6876043893088526,
+              "excess_vs_buy_hold": 0.8982073869899239
+            },
+            "regime_switch": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 6.018335692134347
+            },
+            "ma_boll_fixed": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": 6.018335692134347
+            }
+          }
+        },
+        {
+          "fold": 9,
+          "test_start": "2025-07-06 00:00:00",
+          "test_end": "2025-08-04 00:00:00",
+          "market_return": 22.348220516399152,
+          "regime_counts": {
+            "BEAR": 17,
+            "RANGE": 13
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -25.427002664854314
+            },
+            "buy_hold": {
+              "return": 25.427002664854314,
+              "max_drawdown": 30.23561643835616,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": -14.740706240324574,
+              "max_drawdown": 24.986504109589067,
+              "transactions": 2,
+              "turnover": 2.0,
+              "mean_exposure": 0.43333333333333335,
+              "excess_vs_buy_hold": -40.167708905178884
+            },
+            "dual_ma_50_200": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -25.427002664854314
+            },
+            "volatility_target": {
+              "return": 21.10348138285616,
+              "max_drawdown": 17.90111638487326,
+              "transactions": 3,
+              "turnover": 0.9771421178703108,
+              "mean_exposure": 0.6131158917476752,
+              "excess_vs_buy_hold": -4.323521281998154
+            },
+            "regime_switch": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -25.427002664854314
+            },
+            "ma_boll_fixed": {
+              "return": -0.808,
+              "max_drawdown": 8.12,
+              "transactions": 9,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": -26.235002664854314
+            }
+          }
+        },
+        {
+          "fold": 10,
+          "test_start": "2025-08-05 00:00:00",
+          "test_end": "2025-09-03 00:00:00",
+          "market_return": 10.25474200490466,
+          "regime_counts": {
+            "RANGE": 28,
+            "BEAR": 2
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -2.518453122122688
+            },
+            "buy_hold": {
+              "return": 2.518453122122688,
+              "max_drawdown": 14.455518340004897,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": -11.666757375414182,
+              "max_drawdown": 14.455518340004902,
+              "transactions": 3,
+              "turnover": 3.0,
+              "mean_exposure": 0.9333333333333333,
+              "excess_vs_buy_hold": -14.18521049753687
+            },
+            "dual_ma_50_200": {
+              "return": -8.541123874852985,
+              "max_drawdown": 14.455518340004907,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 0.7333333333333333,
+              "excess_vs_buy_hold": -11.059576996975673
+            },
+            "volatility_target": {
+              "return": 1.2029720719866521,
+              "max_drawdown": 7.375901790173546,
+              "transactions": 1,
+              "turnover": 0.47766307874443836,
+              "mean_exposure": 0.48663730657540694,
+              "excess_vs_buy_hold": -1.315481050136036
+            },
+            "regime_switch": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -2.518453122122688
+            },
+            "ma_boll_fixed": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": -2.518453122122688
+            }
+          }
+        },
+        {
+          "fold": 11,
+          "test_start": "2025-09-04 00:00:00",
+          "test_end": "2025-10-03 00:00:00",
+          "market_return": 21.552657596158365,
+          "regime_counts": {
+            "RANGE": 15,
+            "BULL": 15
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -14.740547695608974
+            },
+            "buy_hold": {
+              "return": 14.740547695608974,
+              "max_drawdown": 22.96634183426636,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 14.740547695608974,
+              "max_drawdown": 22.96634183426636,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "dual_ma_50_200": {
+              "return": 14.740547695608974,
+              "max_drawdown": 22.96634183426636,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "volatility_target": {
+              "return": 6.931777390634841,
+              "max_drawdown": 17.053293049516633,
+              "transactions": 3,
+              "turnover": 0.7916903204266147,
+              "mean_exposure": 0.6572434655978971,
+              "excess_vs_buy_hold": -7.808770304974133
+            },
+            "regime_switch": {
+              "return": -9.257098444347134,
+              "max_drawdown": 21.65301671332686,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 0.5,
+              "excess_vs_buy_hold": -23.99764613995611
+            },
+            "ma_boll_fixed": {
+              "return": -11.042,
+              "max_drawdown": 12.36,
+              "transactions": 6,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": -25.782547695608976
+            }
+          }
+        },
+        {
+          "fold": 12,
+          "test_start": "2025-10-04 00:00:00",
+          "test_end": "2025-11-02 00:00:00",
+          "market_return": -25.697655876255787,
+          "regime_counts": {
+            "BULL": 9,
+            "RANGE": 21
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 29.327266714462187
+            },
+            "buy_hold": {
+              "return": -29.327266714462187,
+              "max_drawdown": 31.331052888771932,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": -32.090143397045544,
+              "max_drawdown": 32.67914573777115,
+              "transactions": 4,
+              "turnover": 4.0,
+              "mean_exposure": 0.3,
+              "excess_vs_buy_hold": -2.7628766825833573
+            },
+            "dual_ma_50_200": {
+              "return": -29.327266714462187,
+              "max_drawdown": 31.331052888771932,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "volatility_target": {
+              "return": -20.053881629412086,
+              "max_drawdown": 20.655454712072576,
+              "transactions": 4,
+              "turnover": 1.3349504845302986,
+              "mean_exposure": 0.5058400829886379,
+              "excess_vs_buy_hold": 9.273385085050101
+            },
+            "regime_switch": {
+              "return": -29.327266714462187,
+              "max_drawdown": 31.331052888771932,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "ma_boll_fixed": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": 29.327266714462187
+            }
+          }
+        },
+        {
+          "fold": 13,
+          "test_start": "2025-11-03 00:00:00",
+          "test_end": "2025-12-02 00:00:00",
+          "market_return": -12.926348485753536,
+          "regime_counts": {
+            "RANGE": 17,
+            "BEAR": 13
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 23.4337206331412
+            },
+            "buy_hold": {
+              "return": -23.4337206331412,
+              "max_drawdown": 25.479949392155792,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 23.4337206331412
+            },
+            "dual_ma_50_200": {
+              "return": -6.522507757814367,
+              "max_drawdown": 3.4466280389463027,
+              "transactions": 2,
+              "turnover": 2.0,
+              "mean_exposure": 0.26666666666666666,
+              "excess_vs_buy_hold": 16.911212875326832
+            },
+            "volatility_target": {
+              "return": -18.76643623462654,
+              "max_drawdown": 18.09640253644011,
+              "transactions": 4,
+              "turnover": 1.3966248783192547,
+              "mean_exposure": 0.6546872105284359,
+              "excess_vs_buy_hold": 4.66728439851466
+            },
+            "regime_switch": {
+              "return": -20.504535561010684,
+              "max_drawdown": 16.746409703504057,
+              "transactions": 2,
+              "turnover": 2.0,
+              "mean_exposure": 0.5666666666666667,
+              "excess_vs_buy_hold": 2.9291850721305153
+            },
+            "ma_boll_fixed": {
+              "return": -4.898,
+              "max_drawdown": 6.32,
+              "transactions": 3,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": 18.5357206331412
+            }
+          }
+        },
+        {
+          "fold": 14,
+          "test_start": "2025-12-03 00:00:00",
+          "test_end": "2026-01-01 00:00:00",
+          "market_return": -16.372148226295657,
+          "regime_counts": {
+            "BEAR": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 14.824234621188936
+            },
+            "buy_hold": {
+              "return": -14.824234621188936,
+              "max_drawdown": 22.54384808123433,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 14.824234621188936
+            },
+            "dual_ma_50_200": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 14.824234621188936
+            },
+            "volatility_target": {
+              "return": -11.152012177099602,
+              "max_drawdown": 18.25396528181305,
+              "transactions": 4,
+              "turnover": 0.9664973471118278,
+              "mean_exposure": 0.7455719952588505,
+              "excess_vs_buy_hold": 3.672222444089334
+            },
+            "regime_switch": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 14.824234621188936
+            },
+            "ma_boll_fixed": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": 14.824234621188936
+            }
+          }
+        },
+        {
+          "fold": 15,
+          "test_start": "2026-01-02 00:00:00",
+          "test_end": "2026-01-31 00:00:00",
+          "market_return": -26.5153650972653,
+          "regime_counts": {
+            "BEAR": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 19.51369872833363
+            },
+            "buy_hold": {
+              "return": -19.51369872833363,
+              "max_drawdown": 31.27677806341046,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 19.51369872833363
+            },
+            "dual_ma_50_200": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 19.51369872833363
+            },
+            "volatility_target": {
+              "return": -15.222249673829358,
+              "max_drawdown": 23.829632933519203,
+              "transactions": 3,
+              "turnover": 1.2090011166604167,
+              "mean_exposure": 0.6785853045286461,
+              "excess_vs_buy_hold": 4.291449054504271
+            },
+            "regime_switch": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 19.51369872833363
+            },
+            "ma_boll_fixed": {
+              "return": -15.794,
+              "max_drawdown": 11.39,
+              "transactions": 3,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": 3.719698728333629
+            }
+          }
+        },
+        {
+          "fold": 16,
+          "test_start": "2026-02-01 00:00:00",
+          "test_end": "2026-03-02 00:00:00",
+          "market_return": -10.262804527143675,
+          "regime_counts": {
+            "BEAR": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 12.145403033567238
+            },
+            "buy_hold": {
+              "return": -12.145403033567238,
+              "max_drawdown": 18.00407709414381,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 12.145403033567238
+            },
+            "dual_ma_50_200": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 12.145403033567238
+            },
+            "volatility_target": {
+              "return": -9.902820865588435,
+              "max_drawdown": 14.491748467906687,
+              "transactions": 6,
+              "turnover": 1.3419258420795757,
+              "mean_exposure": 0.5042590424895786,
+              "excess_vs_buy_hold": 2.242582167978803
+            },
+            "regime_switch": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 12.145403033567238
+            },
+            "ma_boll_fixed": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": 12.145403033567238
+            }
+          }
+        },
+        {
+          "fold": 17,
+          "test_start": "2026-03-03 00:00:00",
+          "test_end": "2026-04-01 00:00:00",
+          "market_return": 2.4674891630543483,
+          "regime_counts": {
+            "BEAR": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 3.531483480179509
+            },
+            "buy_hold": {
+              "return": -3.531483480179509,
+              "max_drawdown": 12.548524844720513,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 3.531483480179509
+            },
+            "dual_ma_50_200": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 3.531483480179509
+            },
+            "volatility_target": {
+              "return": -3.1057741107216152,
+              "max_drawdown": 10.117775868880278,
+              "transactions": 4,
+              "turnover": 1.008384113574299,
+              "mean_exposure": 0.7058209381812751,
+              "excess_vs_buy_hold": 0.42570936945789395
+            },
+            "regime_switch": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 3.531483480179509
+            },
+            "ma_boll_fixed": {
+              "return": 1.912,
+              "max_drawdown": 3.04,
+              "transactions": 4,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": 5.443483480179509
+            }
+          }
+        },
+        {
+          "fold": 18,
+          "test_start": "2026-04-02 00:00:00",
+          "test_end": "2026-05-01 00:00:00",
+          "market_return": 20.055309734513283,
+          "regime_counts": {
+            "BEAR": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -15.267028480306877
+            },
+            "buy_hold": {
+              "return": 15.267028480306877,
+              "max_drawdown": 6.427924756060747,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -15.267028480306877
+            },
+            "dual_ma_50_200": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -15.267028480306877
+            },
+            "volatility_target": {
+              "return": 15.267028480306877,
+              "max_drawdown": 6.427924756060747,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "regime_switch": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -15.267028480306877
+            },
+            "ma_boll_fixed": {
+              "return": 3.756,
+              "max_drawdown": 1.97,
+              "transactions": 4,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": -11.511028480306877
+            }
+          }
+        },
+        {
+          "fold": 19,
+          "test_start": "2026-05-02 00:00:00",
+          "test_end": "2026-05-31 00:00:00",
+          "market_return": -7.464749792645831,
+          "regime_counts": {
+            "BEAR": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 9.422743477843431
+            },
+            "buy_hold": {
+              "return": -9.422743477843431,
+              "max_drawdown": 13.762341936601402,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 9.422743477843431
+            },
+            "dual_ma_50_200": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 9.422743477843431
+            },
+            "volatility_target": {
+              "return": -9.422743477843431,
+              "max_drawdown": 13.762341936601402,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "regime_switch": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 9.422743477843431
+            },
+            "ma_boll_fixed": {
+              "return": -6.153,
+              "max_drawdown": 6.8500000000000005,
+              "transactions": 6,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": 3.2697434778434316
+            }
+          }
+        },
+        {
+          "fold": 20,
+          "test_start": "2026-06-01 00:00:00",
+          "test_end": "2026-06-30 00:00:00",
+          "market_return": -28.704253214638964,
+          "regime_counts": {
+            "BEAR": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 29.727313117076104
+            },
+            "buy_hold": {
+              "return": -29.727313117076104,
+              "max_drawdown": 28.704253214638964,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 29.727313117076104
+            },
+            "dual_ma_50_200": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 29.727313117076104
+            },
+            "volatility_target": {
+              "return": -29.501346820555852,
+              "max_drawdown": 28.47499720389935,
+              "transactions": 3,
+              "turnover": 1.2276907429404764,
+              "mean_exposure": 0.9346681082929538,
+              "excess_vs_buy_hold": 0.22596629652025157
+            },
+            "regime_switch": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 29.727313117076104
+            },
+            "ma_boll_fixed": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": 29.727313117076104
+            }
+          }
+        },
+        {
+          "fold": 21,
+          "test_start": "2026-07-01 00:00:00",
+          "test_end": "2026-07-30 00:00:00",
+          "market_return": -2.256992522846868,
+          "regime_counts": {
+            "BEAR": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 4.121682978508723
+            },
+            "buy_hold": {
+              "return": -4.121682978508723,
+              "max_drawdown": 11.133941184024646,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 4.121682978508723
+            },
+            "dual_ma_50_200": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 4.121682978508723
+            },
+            "volatility_target": {
+              "return": -4.121682978508723,
+              "max_drawdown": 11.133941184024646,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "regime_switch": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 4.121682978508723
+            },
+            "ma_boll_fixed": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": 4.121682978508723
+            }
+          }
+        }
+      ],
+      "summary": {
+        "cash": {
+          "continuous_oos_return": 0.0,
+          "continuous_excess_vs_buy_hold": 64.23850405739151,
+          "fold_compounded_return": 0.0,
+          "mean_fold_return": 0.0,
+          "median_fold_return": 0.0,
+          "mean_excess_vs_buy_hold": 2.691714243059463,
+          "excess_win_rate": 0.7142857142857143,
+          "continuous_transactions": 0,
+          "continuous_turnover": 0.0,
+          "continuous_max_drawdown": 0.0,
+          "mean_fold_max_drawdown": 0.0
+        },
+        "buy_hold": {
+          "continuous_oos_return": -64.23850405739151,
+          "continuous_excess_vs_buy_hold": 0.0,
+          "fold_compounded_return": -76.59973104483919,
+          "mean_fold_return": -2.691714243059463,
+          "median_fold_return": -9.422743477843431,
+          "mean_excess_vs_buy_hold": 0.0,
+          "excess_win_rate": 0.0,
+          "continuous_transactions": 1,
+          "continuous_turnover": 1.0,
+          "continuous_max_drawdown": 85.16135949394231,
+          "mean_fold_max_drawdown": 22.12714578881881
+        },
+        "sma200_trend": {
+          "continuous_oos_return": -36.09659605367182,
+          "continuous_excess_vs_buy_hold": 28.141908003719692,
+          "fold_compounded_return": -42.52238923052734,
+          "mean_fold_return": 0.6142022575263626,
+          "median_fold_return": 0.0,
+          "mean_excess_vs_buy_hold": 3.3059165005858255,
+          "excess_win_rate": 0.5714285714285714,
+          "continuous_transactions": 10,
+          "continuous_turnover": 10.0,
+          "continuous_max_drawdown": 72.95172858818802,
+          "mean_fold_max_drawdown": 9.55980514197927
+        },
+        "dual_ma_50_200": {
+          "continuous_oos_return": -36.99282497416901,
+          "continuous_excess_vs_buy_hold": 27.245679083222498,
+          "fold_compounded_return": -45.68155804924648,
+          "mean_fold_return": 0.3408926421632882,
+          "median_fold_return": 0.0,
+          "mean_excess_vs_buy_hold": 3.032606885222751,
+          "excess_win_rate": 0.5238095238095238,
+          "continuous_transactions": 4,
+          "continuous_turnover": 4.0,
+          "continuous_max_drawdown": 75.77762573759242,
+          "mean_fold_max_drawdown": 9.550020983048842
+        },
+        "volatility_target": {
+          "continuous_oos_return": -56.915261686530584,
+          "continuous_excess_vs_buy_hold": 7.323242370860925,
+          "fold_compounded_return": -68.96038393578787,
+          "mean_fold_return": -4.259613108162166,
+          "median_fold_return": -9.422743477843431,
+          "mean_excess_vs_buy_hold": -1.5678988651027033,
+          "excess_win_rate": 0.6190476190476191,
+          "continuous_transactions": 50,
+          "continuous_turnover": 8.102916099262313,
+          "continuous_max_drawdown": 70.19125129392773,
+          "mean_fold_max_drawdown": 15.631436718236907
+        },
+        "regime_switch": {
+          "continuous_oos_return": -75.21457556552961,
+          "continuous_excess_vs_buy_hold": -10.976071508138105,
+          "fold_compounded_return": -78.63250276152478,
+          "mean_fold_return": -5.932695831965233,
+          "median_fold_return": 0.0,
+          "mean_excess_vs_buy_hold": -3.2409815889057705,
+          "excess_win_rate": 0.47619047619047616,
+          "continuous_transactions": 6,
+          "continuous_turnover": 6.0,
+          "continuous_max_drawdown": 80.92641457010649,
+          "mean_fold_max_drawdown": 10.208553036040408
+        },
+        "ma_boll_fixed": {
+          "continuous_oos_return": -43.752,
+          "continuous_excess_vs_buy_hold": 20.486504057391507,
+          "fold_compounded_return": -58.80154890448346,
+          "mean_fold_return": -3.929666666666667,
+          "median_fold_return": 0.0,
+          "mean_excess_vs_buy_hold": -1.2379524236072041,
+          "excess_win_rate": 0.6666666666666666,
+          "continuous_transactions": 113,
+          "continuous_turnover": null,
+          "continuous_max_drawdown": 46.28,
+          "mean_fold_max_drawdown": 5.212380952380952
+        }
+      }
+    },
+    {
+      "symbol": "AAVE",
+      "data_start": "2023-08-04 00:00:00",
+      "data_end": "2026-08-02 00:00:00",
+      "data_rows": 1095,
+      "folds": [
+        {
+          "fold": 1,
+          "test_start": "2024-11-08 00:00:00",
+          "test_end": "2024-12-07 00:00:00",
+          "market_return": 55.10607892711883,
+          "regime_counts": {
+            "BULL": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -50.52834274802238
+            },
+            "buy_hold": {
+              "return": 50.52834274802238,
+              "max_drawdown": 19.749168159713328,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 50.52834274802238,
+              "max_drawdown": 19.749168159713328,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "dual_ma_50_200": {
+              "return": 50.52834274802238,
+              "max_drawdown": 19.749168159713328,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "volatility_target": {
+              "return": 23.04158581374476,
+              "max_drawdown": 7.401438881390378,
+              "transactions": 4,
+              "turnover": 0.7938413572694236,
+              "mean_exposure": 0.397264686618424,
+              "excess_vs_buy_hold": -27.486756934277622
+            },
+            "regime_switch": {
+              "return": 50.52834274802238,
+              "max_drawdown": 19.749168159713328,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "ma_boll_fixed": {
+              "return": -0.311,
+              "max_drawdown": 5.43,
+              "transactions": 8,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": -50.83934274802238
+            }
+          }
+        },
+        {
+          "fold": 2,
+          "test_start": "2024-12-08 00:00:00",
+          "test_end": "2025-01-06 00:00:00",
+          "market_return": 20.83362819333381,
+          "regime_counts": {
+            "BULL": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -18.525122070215684
+            },
+            "buy_hold": {
+              "return": 18.525122070215684,
+              "max_drawdown": 21.14046187915217,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 18.525122070215684,
+              "max_drawdown": 21.14046187915217,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "dual_ma_50_200": {
+              "return": 18.525122070215684,
+              "max_drawdown": 21.14046187915217,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "volatility_target": {
+              "return": 8.801978339292571,
+              "max_drawdown": 7.719680464524559,
+              "transactions": 2,
+              "turnover": 0.5723839729511888,
+              "mean_exposure": 0.35891967003532604,
+              "excess_vs_buy_hold": -9.723143730923113
+            },
+            "regime_switch": {
+              "return": 18.525122070215684,
+              "max_drawdown": 21.14046187915217,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "ma_boll_fixed": {
+              "return": 1.321,
+              "max_drawdown": 11.42,
+              "transactions": 10,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": -17.204122070215682
+            }
+          }
+        },
+        {
+          "fold": 3,
+          "test_start": "2025-01-07 00:00:00",
+          "test_end": "2025-02-05 00:00:00",
+          "market_return": -15.370828988529727,
+          "regime_counts": {
+            "BULL": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 25.55002973133682
+            },
+            "buy_hold": {
+              "return": -25.55002973133682,
+              "max_drawdown": 30.30204962243797,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": -25.55002973133682,
+              "max_drawdown": 30.30204962243797,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "dual_ma_50_200": {
+              "return": -25.55002973133682,
+              "max_drawdown": 30.30204962243797,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "volatility_target": {
+              "return": -8.5444891488062,
+              "max_drawdown": 15.554170266666997,
+              "transactions": 3,
+              "turnover": 0.7323864080621544,
+              "mean_exposure": 0.4717199459032602,
+              "excess_vs_buy_hold": 17.00554058253062
+            },
+            "regime_switch": {
+              "return": -25.55002973133682,
+              "max_drawdown": 30.30204962243797,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "ma_boll_fixed": {
+              "return": -10.817,
+              "max_drawdown": 10.82,
+              "transactions": 4,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": 14.73302973133682
+            }
+          }
+        },
+        {
+          "fold": 4,
+          "test_start": "2025-02-06 00:00:00",
+          "test_end": "2025-03-07 00:00:00",
+          "market_return": -18.568825575617034,
+          "regime_counts": {
+            "BULL": 21,
+            "RANGE": 9
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 25.87321038285576
+            },
+            "buy_hold": {
+              "return": -25.87321038285576,
+              "max_drawdown": 31.621121064368594,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": -45.409723563702364,
+              "max_drawdown": 45.264212573023265,
+              "transactions": 6,
+              "turnover": 6.0,
+              "mean_exposure": 0.7,
+              "excess_vs_buy_hold": -19.536513180846605
+            },
+            "dual_ma_50_200": {
+              "return": -25.87321038285576,
+              "max_drawdown": 31.621121064368594,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "volatility_target": {
+              "return": -14.493888381275788,
+              "max_drawdown": 18.138140498137734,
+              "transactions": 5,
+              "turnover": 0.9697503867482864,
+              "mean_exposure": 0.4880895759997477,
+              "excess_vs_buy_hold": 11.379322001579972
+            },
+            "regime_switch": {
+              "return": -25.87321038285576,
+              "max_drawdown": 31.621121064368594,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "ma_boll_fixed": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": 25.87321038285576
+            }
+          }
+        },
+        {
+          "fold": 5,
+          "test_start": "2025-03-08 00:00:00",
+          "test_end": "2025-04-06 00:00:00",
+          "market_return": -34.09625012772045,
+          "regime_counts": {
+            "RANGE": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 35.77741861494721
+            },
+            "buy_hold": {
+              "return": -35.77741861494721,
+              "max_drawdown": 34.09625012772045,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 35.77741861494721
+            },
+            "dual_ma_50_200": {
+              "return": -12.374403482101426,
+              "max_drawdown": 16.823337079799746,
+              "transactions": 2,
+              "turnover": 2.0,
+              "mean_exposure": 0.5,
+              "excess_vs_buy_hold": 23.40301513284578
+            },
+            "volatility_target": {
+              "return": -20.726124808272484,
+              "max_drawdown": 20.05237550208938,
+              "transactions": 3,
+              "turnover": 0.615753358683645,
+              "mean_exposure": 0.41689187215299334,
+              "excess_vs_buy_hold": 15.051293806674725
+            },
+            "regime_switch": {
+              "return": -35.77741861494721,
+              "max_drawdown": 34.09625012772045,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "ma_boll_fixed": {
+              "return": -6.443,
+              "max_drawdown": 5.59,
+              "transactions": 4,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": 29.33441861494721
+            }
+          }
+        },
+        {
+          "fold": 6,
+          "test_start": "2025-04-07 00:00:00",
+          "test_end": "2025-05-06 00:00:00",
+          "market_return": 34.681511777626284,
+          "regime_counts": {
+            "RANGE": 14,
+            "BEAR": 16
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -34.90082176637777
+            },
+            "buy_hold": {
+              "return": 34.90082176637777,
+              "max_drawdown": 9.534098582039165,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -34.90082176637777
+            },
+            "dual_ma_50_200": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -34.90082176637777
+            },
+            "volatility_target": {
+              "return": 16.27009721464121,
+              "max_drawdown": 4.360084020285708,
+              "transactions": 4,
+              "turnover": 0.8497888849599062,
+              "mean_exposure": 0.5156074606037535,
+              "excess_vs_buy_hold": -18.630724551736556
+            },
+            "regime_switch": {
+              "return": -0.31944907784967613,
+              "max_drawdown": 11.28003092505063,
+              "transactions": 2,
+              "turnover": 2.0,
+              "mean_exposure": 0.3,
+              "excess_vs_buy_hold": -35.22027084422744
+            },
+            "ma_boll_fixed": {
+              "return": 1.825,
+              "max_drawdown": 1.51,
+              "transactions": 4,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": -33.075821766377764
+            }
+          }
+        },
+        {
+          "fold": 7,
+          "test_start": "2025-05-07 00:00:00",
+          "test_end": "2025-06-05 00:00:00",
+          "market_return": 40.43690448524284,
+          "regime_counts": {
+            "RANGE": 8,
+            "BULL": 22
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -33.06846100368368
+            },
+            "buy_hold": {
+              "return": 33.06846100368368,
+              "max_drawdown": 10.991641197481309,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": -20.875569878529955,
+              "max_drawdown": 22.389840992802355,
+              "transactions": 7,
+              "turnover": 7.0,
+              "mean_exposure": 0.7333333333333334,
+              "excess_vs_buy_hold": -53.94403088221364
+            },
+            "dual_ma_50_200": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -33.06846100368368
+            },
+            "volatility_target": {
+              "return": 17.240055546123155,
+              "max_drawdown": 7.745053232677813,
+              "transactions": 3,
+              "turnover": 1.2386955556273511,
+              "mean_exposure": 0.5941764679057685,
+              "excess_vs_buy_hold": -15.828405457560525
+            },
+            "regime_switch": {
+              "return": -7.1692323245300615,
+              "max_drawdown": 14.677264378375165,
+              "transactions": 3,
+              "turnover": 3.0,
+              "mean_exposure": 0.8,
+              "excess_vs_buy_hold": -40.237693328213744
+            },
+            "ma_boll_fixed": {
+              "return": 17.688,
+              "max_drawdown": 1.66,
+              "transactions": 11,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": -15.380461003683681
+            }
+          }
+        },
+        {
+          "fold": 8,
+          "test_start": "2025-06-06 00:00:00",
+          "test_end": "2025-07-05 00:00:00",
+          "market_return": 9.03583243652597,
+          "regime_counts": {
+            "BULL": 26,
+            "RANGE": 4
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -10.798022100355386
+            },
+            "buy_hold": {
+              "return": 10.798022100355386,
+              "max_drawdown": 26.08808458195498,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": -3.0152250060132446,
+              "max_drawdown": 28.943708674845432,
+              "transactions": 3,
+              "turnover": 3.0,
+              "mean_exposure": 0.9333333333333333,
+              "excess_vs_buy_hold": -13.81324710636863
+            },
+            "dual_ma_50_200": {
+              "return": 4.7526025818355855,
+              "max_drawdown": 12.731692760636307,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 0.5333333333333333,
+              "excess_vs_buy_hold": -6.0454195185198
+            },
+            "volatility_target": {
+              "return": 8.678320522023997,
+              "max_drawdown": 15.836667032258372,
+              "transactions": 2,
+              "turnover": 0.8045867099979795,
+              "mean_exposure": 0.5845854934120743,
+              "excess_vs_buy_hold": -2.119701578331389
+            },
+            "regime_switch": {
+              "return": 10.798022100355386,
+              "max_drawdown": 26.08808458195498,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "ma_boll_fixed": {
+              "return": -8.243,
+              "max_drawdown": 9.719999999999999,
+              "transactions": 6,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": -19.041022100355384
+            }
+          }
+        },
+        {
+          "fold": 9,
+          "test_start": "2025-07-06 00:00:00",
+          "test_end": "2025-08-04 00:00:00",
+          "market_return": -6.796589524969554,
+          "regime_counts": {
+            "RANGE": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 4.159149571825926
+            },
+            "buy_hold": {
+              "return": -4.159149571825926,
+              "max_drawdown": 23.836712261846593,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": -4.159149571825926,
+              "max_drawdown": 23.836712261846593,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "dual_ma_50_200": {
+              "return": -4.159149571825926,
+              "max_drawdown": 23.836712261846593,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "volatility_target": {
+              "return": -8.638480664927151,
+              "max_drawdown": 22.788098511474274,
+              "transactions": 3,
+              "turnover": 0.9218663622063444,
+              "mean_exposure": 0.8010367266725184,
+              "excess_vs_buy_hold": -4.479331093101225
+            },
+            "regime_switch": {
+              "return": 15.2784633567971,
+              "max_drawdown": 8.389932524274839,
+              "transactions": 3,
+              "turnover": 3.0,
+              "mean_exposure": 0.4666666666666667,
+              "excess_vs_buy_hold": 19.437612928623025
+            },
+            "ma_boll_fixed": {
+              "return": -9.373,
+              "max_drawdown": 9.86,
+              "transactions": 11,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": -5.213850428174073
+            }
+          }
+        },
+        {
+          "fold": 10,
+          "test_start": "2025-08-05 00:00:00",
+          "test_end": "2025-09-03 00:00:00",
+          "market_return": 28.38012451544698,
+          "regime_counts": {
+            "RANGE": 21,
+            "BULL": 9
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -19.849011832732888
+            },
+            "buy_hold": {
+              "return": 19.849011832732888,
+              "max_drawdown": 16.47749510763208,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 19.849011832732888,
+              "max_drawdown": 16.47749510763208,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "dual_ma_50_200": {
+              "return": 19.849011832732888,
+              "max_drawdown": 16.47749510763208,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "volatility_target": {
+              "return": 14.3496437434123,
+              "max_drawdown": 10.183032313886489,
+              "transactions": 4,
+              "turnover": 1.3799882636198346,
+              "mean_exposure": 0.5922182381928895,
+              "excess_vs_buy_hold": -5.499368089320589
+            },
+            "regime_switch": {
+              "return": 16.2073219694274,
+              "max_drawdown": 9.191910165907139,
+              "transactions": 3,
+              "turnover": 3.0,
+              "mean_exposure": 0.5666666666666667,
+              "excess_vs_buy_hold": -3.641689863305487
+            },
+            "ma_boll_fixed": {
+              "return": 5.651,
+              "max_drawdown": 7.090000000000001,
+              "transactions": 4,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": -14.198011832732888
+            }
+          }
+        },
+        {
+          "fold": 11,
+          "test_start": "2025-09-04 00:00:00",
+          "test_end": "2025-10-03 00:00:00",
+          "market_return": -5.22607163828539,
+          "regime_counts": {
+            "BULL": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 13.24533328498555
+            },
+            "buy_hold": {
+              "return": -13.24533328498555,
+              "max_drawdown": 19.084491712535375,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": -13.24533328498555,
+              "max_drawdown": 19.084491712535375,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "dual_ma_50_200": {
+              "return": -13.24533328498555,
+              "max_drawdown": 19.084491712535375,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "volatility_target": {
+              "return": -12.427480199636399,
+              "max_drawdown": 19.03445170989668,
+              "transactions": 8,
+              "turnover": 1.4900892076743588,
+              "mean_exposure": 0.7883952990578014,
+              "excess_vs_buy_hold": 0.8178530853491512
+            },
+            "regime_switch": {
+              "return": -13.24533328498555,
+              "max_drawdown": 19.084491712535375,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "ma_boll_fixed": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": 13.24533328498555
+            }
+          }
+        },
+        {
+          "fold": 12,
+          "test_start": "2025-10-04 00:00:00",
+          "test_end": "2025-11-02 00:00:00",
+          "market_return": -18.295783600536765,
+          "regime_counts": {
+            "BULL": 8,
+            "RANGE": 22
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 22.03349605339072
+            },
+            "buy_hold": {
+              "return": -22.03349605339072,
+              "max_drawdown": 30.482921083627794,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": -30.530380442228378,
+              "max_drawdown": 30.62257576675867,
+              "transactions": 4,
+              "turnover": 4.0,
+              "mean_exposure": 0.26666666666666666,
+              "excess_vs_buy_hold": -8.496884388837657
+            },
+            "dual_ma_50_200": {
+              "return": -24.632564069668682,
+              "max_drawdown": 30.482921083627794,
+              "transactions": 2,
+              "turnover": 2.0,
+              "mean_exposure": 0.9333333333333333,
+              "excess_vs_buy_hold": -2.599068016277961
+            },
+            "volatility_target": {
+              "return": -17.09573638572689,
+              "max_drawdown": 22.069225023281348,
+              "transactions": 4,
+              "turnover": 1.235615225079131,
+              "mean_exposure": 0.5809401274922115,
+              "excess_vs_buy_hold": 4.93775966766383
+            },
+            "regime_switch": {
+              "return": -22.03349605339072,
+              "max_drawdown": 30.482921083627794,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "ma_boll_fixed": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": 22.03349605339072
+            }
+          }
+        },
+        {
+          "fold": 13,
+          "test_start": "2025-11-03 00:00:00",
+          "test_end": "2025-12-02 00:00:00",
+          "market_return": -4.903581267217627,
+          "regime_counts": {
+            "RANGE": 27,
+            "BEAR": 3
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 19.659006277263526
+            },
+            "buy_hold": {
+              "return": -19.659006277263526,
+              "max_drawdown": 30.900573530055592,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 19.659006277263526
+            },
+            "dual_ma_50_200": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 19.659006277263526
+            },
+            "volatility_target": {
+              "return": -9.886251334083862,
+              "max_drawdown": 15.535132115014175,
+              "transactions": 3,
+              "turnover": 0.8656883000345816,
+              "mean_exposure": 0.4833139669964128,
+              "excess_vs_buy_hold": 9.772754943179663
+            },
+            "regime_switch": {
+              "return": -24.57595413922178,
+              "max_drawdown": 30.900573530055592,
+              "transactions": 2,
+              "turnover": 2.0,
+              "mean_exposure": 0.9,
+              "excess_vs_buy_hold": -4.916947861958253
+            },
+            "ma_boll_fixed": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": 19.659006277263526
+            }
+          }
+        },
+        {
+          "fold": 14,
+          "test_start": "2025-12-03 00:00:00",
+          "test_end": "2026-01-01 00:00:00",
+          "market_return": -24.733410825289326,
+          "regime_counts": {
+            "BEAR": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 23.211715606912552
+            },
+            "buy_hold": {
+              "return": -23.211715606912552,
+              "max_drawdown": 27.873549024450465,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 23.211715606912552
+            },
+            "dual_ma_50_200": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 23.211715606912552
+            },
+            "volatility_target": {
+              "return": -15.023231191003072,
+              "max_drawdown": 18.431178886383968,
+              "transactions": 3,
+              "turnover": 0.7713418893592284,
+              "mean_exposure": 0.6136664996244943,
+              "excess_vs_buy_hold": 8.18848441590948
+            },
+            "regime_switch": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 23.211715606912552
+            },
+            "ma_boll_fixed": {
+              "return": 0.407,
+              "max_drawdown": 1.16,
+              "transactions": 8,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": 23.618715606912552
+            }
+          }
+        },
+        {
+          "fold": 15,
+          "test_start": "2026-01-02 00:00:00",
+          "test_end": "2026-01-31 00:00:00",
+          "market_return": -21.8920227575354,
+          "regime_counts": {
+            "BEAR": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 15.166415535716549
+            },
+            "buy_hold": {
+              "return": -15.166415535716549,
+              "max_drawdown": 27.686876611005275,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 15.166415535716549
+            },
+            "dual_ma_50_200": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 15.166415535716549
+            },
+            "volatility_target": {
+              "return": -12.367556190846084,
+              "max_drawdown": 21.772951363445824,
+              "transactions": 6,
+              "turnover": 1.3953806826469193,
+              "mean_exposure": 0.710745769917967,
+              "excess_vs_buy_hold": 2.798859344870465
+            },
+            "regime_switch": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 15.166415535716549
+            },
+            "ma_boll_fixed": {
+              "return": -11.038,
+              "max_drawdown": 9.790000000000001,
+              "transactions": 2,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": 4.128415535716549
+            }
+          }
+        },
+        {
+          "fold": 16,
+          "test_start": "2026-02-01 00:00:00",
+          "test_end": "2026-03-02 00:00:00",
+          "market_return": -1.6260162601626105,
+          "regime_counts": {
+            "BEAR": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 7.28697880964444
+            },
+            "buy_hold": {
+              "return": -7.28697880964444,
+              "max_drawdown": 21.350677675650417,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 7.28697880964444
+            },
+            "dual_ma_50_200": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 7.28697880964444
+            },
+            "volatility_target": {
+              "return": -5.586327545571912,
+              "max_drawdown": 13.576449134301802,
+              "transactions": 4,
+              "turnover": 1.1011380637361603,
+              "mean_exposure": 0.5150937864205766,
+              "excess_vs_buy_hold": 1.700651264072528
+            },
+            "regime_switch": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 7.28697880964444
+            },
+            "ma_boll_fixed": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": 7.28697880964444
+            }
+          }
+        },
+        {
+          "fold": 17,
+          "test_start": "2026-03-03 00:00:00",
+          "test_end": "2026-04-01 00:00:00",
+          "market_return": -11.748830514573594,
+          "regime_counts": {
+            "BEAR": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 21.40592631590995
+            },
+            "buy_hold": {
+              "return": -21.40592631590995,
+              "max_drawdown": 21.989699991825383,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 21.40592631590995
+            },
+            "dual_ma_50_200": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 21.40592631590995
+            },
+            "volatility_target": {
+              "return": -16.470920789979882,
+              "max_drawdown": 17.30732174027014,
+              "transactions": 3,
+              "turnover": 0.8912088112847578,
+              "mean_exposure": 0.7026778133930666,
+              "excess_vs_buy_hold": 4.93500552593007
+            },
+            "regime_switch": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 21.40592631590995
+            },
+            "ma_boll_fixed": {
+              "return": -2.446,
+              "max_drawdown": 5.1,
+              "transactions": 4,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": 18.95992631590995
+            }
+          }
+        },
+        {
+          "fold": 18,
+          "test_start": "2026-04-02 00:00:00",
+          "test_end": "2026-05-01 00:00:00",
+          "market_return": -2.4377318494965494,
+          "regime_counts": {
+            "BEAR": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 8.145060525042169
+            },
+            "buy_hold": {
+              "return": -8.145060525042169,
+              "max_drawdown": 21.80841849991338,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 8.145060525042169
+            },
+            "dual_ma_50_200": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 8.145060525042169
+            },
+            "volatility_target": {
+              "return": -3.1272002429444945,
+              "max_drawdown": 12.748662344387949,
+              "transactions": 4,
+              "turnover": 1.5206208171516244,
+              "mean_exposure": 0.6833329572350952,
+              "excess_vs_buy_hold": 5.017860282097674
+            },
+            "regime_switch": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 8.145060525042169
+            },
+            "ma_boll_fixed": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": 8.145060525042169
+            }
+          }
+        },
+        {
+          "fold": 19,
+          "test_start": "2026-05-02 00:00:00",
+          "test_end": "2026-05-31 00:00:00",
+          "market_return": -11.968284581592204,
+          "regime_counts": {
+            "BEAR": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 12.607166844454964
+            },
+            "buy_hold": {
+              "return": -12.607166844454964,
+              "max_drawdown": 20.88105726872247,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 12.607166844454964
+            },
+            "dual_ma_50_200": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 12.607166844454964
+            },
+            "volatility_target": {
+              "return": -12.491806573909503,
+              "max_drawdown": 19.05956028247957,
+              "transactions": 5,
+              "turnover": 1.0135650063800903,
+              "mean_exposure": 0.8362542525739535,
+              "excess_vs_buy_hold": 0.11536027054546061
+            },
+            "regime_switch": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": 12.607166844454964
+            },
+            "ma_boll_fixed": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": 12.607166844454964
+            }
+          }
+        },
+        {
+          "fold": 20,
+          "test_start": "2026-06-01 00:00:00",
+          "test_end": "2026-06-30 00:00:00",
+          "market_return": 6.0647571606475825,
+          "regime_counts": {
+            "BEAR": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -1.488822764382669
+            },
+            "buy_hold": {
+              "return": 1.488822764382669,
+              "max_drawdown": 24.08468244084682,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -1.488822764382669
+            },
+            "dual_ma_50_200": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -1.488822764382669
+            },
+            "volatility_target": {
+              "return": -9.64926866295962,
+              "max_drawdown": 24.08094889449936,
+              "transactions": 4,
+              "turnover": 1.4608373019910108,
+              "mean_exposure": 0.7161470424456436,
+              "excess_vs_buy_hold": -11.138091427342289
+            },
+            "regime_switch": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -1.488822764382669
+            },
+            "ma_boll_fixed": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": -1.488822764382669
+            }
+          }
+        },
+        {
+          "fold": 21,
+          "test_start": "2026-07-01 00:00:00",
+          "test_end": "2026-07-30 00:00:00",
+          "market_return": 19.60100949405119,
+          "regime_counts": {
+            "BEAR": 30
+          },
+          "strategies": {
+            "cash": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -14.397285232086233
+            },
+            "buy_hold": {
+              "return": 14.397285232086233,
+              "max_drawdown": 9.498787388843969,
+              "transactions": 1,
+              "turnover": 1.0,
+              "mean_exposure": 1.0,
+              "excess_vs_buy_hold": 0.0
+            },
+            "sma200_trend": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -14.397285232086233
+            },
+            "dual_ma_50_200": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -14.397285232086233
+            },
+            "volatility_target": {
+              "return": 9.913459048872664,
+              "max_drawdown": 6.041740444372091,
+              "transactions": 4,
+              "turnover": 1.0419164149764635,
+              "mean_exposure": 0.6469537356088944,
+              "excess_vs_buy_hold": -4.483826183213569
+            },
+            "regime_switch": {
+              "return": 0.0,
+              "max_drawdown": 0.0,
+              "transactions": 0,
+              "turnover": 0.0,
+              "mean_exposure": 0.0,
+              "excess_vs_buy_hold": -14.397285232086233
+            },
+            "ma_boll_fixed": {
+              "return": 4.793,
+              "max_drawdown": 2.45,
+              "transactions": 7,
+              "turnover": null,
+              "mean_exposure": null,
+              "excess_vs_buy_hold": -9.604285232086234
+            }
+          }
+        }
+      ],
+      "summary": {
+        "cash": {
+          "continuous_oos_return": 0.0,
+          "continuous_excess_vs_buy_hold": 46.91502242989657,
+          "fold_compounded_return": 0.0,
+          "mean_fold_return": 0.0,
+          "median_fold_return": 0.0,
+          "mean_excess_vs_buy_hold": 2.4078580017347355,
+          "excess_win_rate": 0.6190476190476191,
+          "continuous_transactions": 0,
+          "continuous_turnover": 0.0,
+          "continuous_max_drawdown": 0.0,
+          "mean_fold_max_drawdown": 0.0
+        },
+        "buy_hold": {
+          "continuous_oos_return": -46.91502242989657,
+          "continuous_excess_vs_buy_hold": 0.0,
+          "fold_compounded_return": -65.26984584118041,
+          "mean_fold_return": -2.4078580017347355,
+          "median_fold_return": -8.145060525042169,
+          "mean_excess_vs_buy_hold": 0.0,
+          "excess_win_rate": 0.0,
+          "continuous_transactions": 1,
+          "continuous_turnover": 1.0,
+          "continuous_max_drawdown": 84.1055458503898,
+          "mean_fold_max_drawdown": 22.832324657705886
+        },
+        "sma200_trend": {
+          "continuous_oos_return": -54.3714456551044,
+          "continuous_excess_vs_buy_hold": -7.4564232252078355,
+          "fold_compounded_return": -61.47917730148229,
+          "mean_fold_return": -2.565854039411966,
+          "median_fold_return": 0.0,
+          "mean_excess_vs_buy_hold": -0.15799603767723044,
+          "excess_win_rate": 0.38095238095238093,
+          "continuous_transactions": 18,
+          "continuous_turnover": 18.0,
+          "continuous_max_drawdown": 77.69634195838496,
+          "mean_fold_max_drawdown": 12.27670079765463
+        },
+        "dual_ma_50_200": {
+          "continuous_oos_return": -19.59386922287979,
+          "continuous_excess_vs_buy_hold": 27.321153207016778,
+          "fold_compounded_return": -32.12248671246023,
+          "mean_fold_return": -0.5799814899984584,
+          "median_fold_return": 0.0,
+          "mean_excess_vs_buy_hold": 1.8278765117362772,
+          "excess_win_rate": 0.38095238095238093,
+          "continuous_transactions": 4,
+          "continuous_turnover": 4.0,
+          "continuous_max_drawdown": 63.699460812437145,
+          "mean_fold_max_drawdown": 10.583307177702379
+        },
+        "volatility_target": {
+          "continuous_oos_return": -48.050972182190975,
+          "continuous_excess_vs_buy_hold": -1.1359497522944082,
+          "fold_compounded_return": -58.45511662833547,
+          "mean_fold_return": -3.2492200900872708,
+          "median_fold_return": -8.638480664927151,
+          "mean_excess_vs_buy_hold": -0.8413620883525351,
+          "excess_win_rate": 0.5714285714285714,
+          "continuous_transactions": 62,
+          "continuous_turnover": 9.328245182423192,
+          "continuous_max_drawdown": 74.49401139952472,
+          "mean_fold_max_drawdown": 15.211255364844028
+        },
+        "regime_switch": {
+          "continuous_oos_return": -44.04747046766971,
+          "continuous_excess_vs_buy_hold": 2.8675519622268553,
+          "fold_compounded_return": -55.69191791120562,
+          "mean_fold_return": -2.0574691125856965,
+          "median_fold_return": 0.0,
+          "mean_excess_vs_buy_hold": 0.35038888914903915,
+          "excess_win_rate": 0.3333333333333333,
+          "continuous_transactions": 10,
+          "continuous_turnover": 10.0,
+          "continuous_max_drawdown": 75.78176059392851,
+          "mean_fold_max_drawdown": 13.666869512151145
+        },
+        "ma_boll_fixed": {
+          "continuous_oos_return": -14.97,
+          "continuous_excess_vs_buy_hold": 31.945022429896568,
+          "fold_compounded_return": -18.97706358219168,
+          "mean_fold_return": -0.8088571428571429,
+          "median_fold_return": 0.0,
+          "mean_excess_vs_buy_hold": 1.599000858877593,
+          "excess_win_rate": 0.5714285714285714,
+          "continuous_transactions": 161,
+          "continuous_turnover": null,
+          "continuous_max_drawdown": 31.75,
+          "mean_fold_max_drawdown": 3.8857142857142857
+        }
+      }
+    }
+  ],
+  "cross_asset_summary": {
+    "cash": {
+      "median_asset_return": 0.0,
+      "median_asset_excess_vs_buy_hold": 49.07822798834453,
+      "positive_return_assets": 0,
+      "positive_excess_assets": 8,
+      "asset_count": 8
+    },
+    "buy_hold": {
+      "median_asset_return": -49.07822798834453,
+      "median_asset_excess_vs_buy_hold": 0.0,
+      "positive_return_assets": 0,
+      "positive_excess_assets": 0,
+      "asset_count": 8
+    },
+    "sma200_trend": {
+      "median_asset_return": -33.331606825050315,
+      "median_asset_excess_vs_buy_hold": 16.134349897431633,
+      "positive_return_assets": 0,
+      "positive_excess_assets": 5,
+      "asset_count": 8
+    },
+    "dual_ma_50_200": {
+      "median_asset_return": -35.4391409023205,
+      "median_asset_excess_vs_buy_hold": 5.699807732452264,
+      "positive_return_assets": 0,
+      "positive_excess_assets": 6,
+      "asset_count": 8
+    },
+    "volatility_target": {
+      "median_asset_return": -44.58395402830831,
+      "median_asset_excess_vs_buy_hold": 2.172710798694382,
+      "positive_return_assets": 0,
+      "positive_excess_assets": 4,
+      "asset_count": 8
+    },
+    "regime_switch": {
+      "median_asset_return": -50.09292377422712,
+      "median_asset_excess_vs_buy_hold": -4.1142899271945055,
+      "positive_return_assets": 1,
+      "positive_excess_assets": 3,
+      "asset_count": 8
+    },
+    "ma_boll_fixed": {
+      "median_asset_return": -42.3855,
+      "median_asset_excess_vs_buy_hold": 9.256442596666478,
+      "positive_return_assets": 0,
+      "positive_excess_assets": 6,
+      "asset_count": 8
+    }
+  }
+}

--- a/tests/backtesting/test_benchmark_validation.py
+++ b/tests/backtesting/test_benchmark_validation.py
@@ -1,0 +1,113 @@
+from datetime import datetime
+
+import pytest
+
+from app.backtesting.benchmark_validation import (
+    EXECUTION_FRICTION_RATE,
+    build_strategy_targets,
+    simulate_target_strategy,
+)
+from app.trading.strat_trader import StratTrader
+from app.trading.strategies import apply_signal_option_leverage
+
+
+def _row(close, day, open_price=None):
+    open_price = close if open_price is None else open_price
+    return [
+        close,
+        f"2024-01-{day:02d} 00:00:00",
+        open_price,
+        close - 1,
+        close + 1,
+        1000,
+    ]
+
+
+def _trader(**overrides):
+    kwargs = {
+        "name": "BTC",
+        "init_amount": 10_000,
+        "stat": "MA-BOLL-BANDS",
+        "tol_pct": 0.1,
+        "ma_lengths": [6, 12, 30],
+        "ema_lengths": [6, 12, 26, 30],
+        "bollinger_mas": [6, 12],
+        "bollinger_sigma": 2,
+        "buy_pct": 0.5,
+        "sell_pct": 0.5,
+    }
+    kwargs.update(overrides)
+    return StratTrader(**kwargs)
+
+
+def test_target_strategy_executes_previous_signal_at_next_open():
+    data = [_row(100, 1), _row(110, 2, open_price=100)]
+    result = simulate_target_strategy(
+        data,
+        targets=[1.0, 1.0],
+        test_start=1,
+        test_end=2,
+        slippage_bps=10,
+    )
+
+    quantity = 10_000 * (1 - EXECUTION_FRICTION_RATE) / 100.1
+    expected_return = (quantity * 110 / 10_000 - 1) * 100
+    assert result["return"] == pytest.approx(expected_return)
+    assert result["transactions"] == 1
+
+
+def test_strat_trader_defers_signal_until_next_open():
+    trader = _trader(execute_on_next_open=True, slippage_bps=10)
+
+    assert trader._execute_one_buy("by_percentage", 100) is True
+    assert trader.cur_coin == 0
+    assert trader.pending_order["action"] == "BUY"
+
+    trader.add_new_day(
+        new_p=110,
+        d=datetime(2024, 1, 2),
+        misc_p={"open": 100, "low": 99, "high": 111, "volume": 1000},
+    )
+
+    expected_quantity = 5_000 * (1 - EXECUTION_FRICTION_RATE) / 100.1
+    assert trader.cur_coin == pytest.approx(expected_quantity)
+    assert trader.trade_history[0]["action"] == "BUY"
+    assert trader.trade_history[0]["price"] == pytest.approx(100.1)
+
+
+def test_options_can_be_disabled_for_backtests():
+    trader = _trader(enable_options=False)
+    cash_before = trader.cash
+
+    result = apply_signal_option_leverage(
+        trader=trader,
+        signal="BUY",
+        price=100,
+        today=datetime(2024, 1, 1),
+    )
+
+    assert result is None
+    assert trader.cash == cash_before
+    assert trader.option_history == []
+
+
+def test_regime_targets_use_shared_fixed_rules():
+    data = []
+    for index in range(260):
+        price = 100 + index * 0.5
+        data.append(
+            [price, f"2024-01-01 00:00:{index:02d}", price, price - 1, price + 1, 1000]
+        )
+
+    features = build_strategy_targets(data)
+
+    assert features["regimes"][-1] == "BULL"
+    assert features["targets"]["regime_switch"][-1] == 1.0
+    assert set(features["targets"]) == {
+        "cash",
+        "buy_hold",
+        "sma200_trend",
+        "dual_ma_50_200",
+        "volatility_target",
+        "regime_switch",
+    }

--- a/tests/backtesting/test_walk_forward.py
+++ b/tests/backtesting/test_walk_forward.py
@@ -1,0 +1,71 @@
+from datetime import datetime, timedelta
+
+import pytest
+
+from app.backtesting.walk_forward import build_walk_forward_folds, compound_returns
+from app.trading.strat_trader import StratTrader
+
+
+def test_folds_have_purge_gap_and_non_overlapping_tests():
+    folds = build_walk_forward_folds(
+        data_length=600,
+        train_days=180,
+        validation_days=60,
+        test_days=30,
+        purge_days=7,
+    )
+
+    assert folds
+    assert folds[0].train_start == 0
+    assert folds[0].train_end == folds[0].validation_start
+    assert folds[0].validation_end == folds[0].purge_start
+    assert folds[0].purge_end == folds[0].test_start
+    assert folds[0].purge_end - folds[0].purge_start == 7
+    assert all(
+        left.test_end <= right.test_start for left, right in zip(folds, folds[1:])
+    )
+
+
+def test_overlapping_test_windows_are_rejected():
+    with pytest.raises(ValueError, match="do not overlap"):
+        build_walk_forward_folds(
+            data_length=600,
+            train_days=180,
+            validation_days=60,
+            test_days=30,
+            purge_days=7,
+            step_days=15,
+        )
+
+
+def test_compound_returns():
+    assert compound_returns([10.0, -10.0]) == pytest.approx(-1.0)
+
+
+def test_indicator_warmup_does_not_trade():
+    trader = StratTrader(
+        name="BTC",
+        init_amount=10_000,
+        stat="MA-BOLL-BANDS",
+        tol_pct=0.1,
+        ma_lengths=[6, 12, 30],
+        ema_lengths=[6, 12, 26, 30],
+        bollinger_mas=[6, 12],
+        bollinger_sigma=2,
+        buy_pct=0.5,
+        sell_pct=0.5,
+    )
+
+    for day in range(40):
+        price = 100 + day
+        trader.add_new_day(
+            price,
+            datetime(2024, 1, 1) + timedelta(days=day),
+            {"open": price, "low": price - 1, "high": price + 1, "volume": 1000},
+            execute_strategy=False,
+        )
+
+    assert len(trader.crypto_prices) == 40
+    assert trader.trade_history == []
+    assert trader.cash == 10_000
+    assert trader.cur_coin == 0


### PR DESCRIPTION
## Summary
- add strict walk-forward backtesting and cross-asset benchmark validation
- model next-open execution, fixed 2% transaction friction, and slippage
- add three-year daily backfill support and benchmark reports

## Validation
- poetry run pytest tests/backtesting -q (8 passed)