### PR TITLE
feat: optimize SMA200 strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -571,11 +571,11 @@ poetry run python app/db/db_management.py stats
 
 # Example output:
 # === Database Statistics ===
-# Symbol         Records    Last Updated
-# --------------------------------------------------
-# BTC-USD        90         2024-01-15 14:30:00
-# ETH-USD        90         2024-01-15 14:30:00
-# SOL-USD        90         2024-01-15 14:30:00
+# Symbol               Records    First Date   Last Date
+# ----------------------------------------------------------
+# BTCUSDT__1d           1095       2023-08-04   2026-08-02
+# ETHUSDT__1d           1095       2023-08-04   2026-08-02
+# SOLUSDT__1d           1095       2023-08-04   2026-08-02
 # 
 # Total symbols: 3
 ```

--- a/app/api/server.py
+++ b/app/api/server.py
@@ -508,11 +508,14 @@ def get_database_stats():
                     {
                         "symbol": symbol,
                         "record_count": count,
-                        "last_updated": last_updated.isoformat()
-                        if last_updated
-                        else None,
+                        "first_recorded": (
+                            first_date.isoformat() if first_date else None
+                        ),
+                        "last_recorded": last_date.isoformat() if last_date else None,
+                        # Backward-compatible alias for existing dashboard clients.
+                        "last_updated": last_date.isoformat() if last_date else None,
                     }
-                    for symbol, count, last_updated in stats
+                    for symbol, count, first_date, last_date in stats
                 ],
             }
         )

--- a/app/backtesting/sma200_variant_validation.py
+++ b/app/backtesting/sma200_variant_validation.py
@@ -1,0 +1,248 @@
+"""Cross-asset, leakage-resistant validation for a small SMA200 variant set."""
+
+import argparse
+import json
+from dataclasses import asdict
+from pathlib import Path
+from statistics import median
+from typing import Any, Sequence
+
+from app.backtesting.walk_forward import (
+    Candidate,
+    _evaluate_candidate,
+    load_daily_data,
+)
+from app.core.config import SMA200_VARIANTS
+
+SMA200_BASELINE_VARIANT = {
+    "entry_band_pct": 0.0,
+    "exit_band_pct": 0.0,
+    "min_hold_days": 0,
+}
+
+
+def _sma_candidate(variant: dict[str, Any]) -> Candidate:
+    return Candidate(
+        strategy="SMA200",
+        tol_pct=0.0,
+        buy_pct=1.0,
+        sell_pct=1.0,
+        bollinger_sigma=2.0,
+        sma200_entry_band_pct=float(variant["entry_band_pct"]),
+        sma200_exit_band_pct=float(variant["exit_band_pct"]),
+        sma200_min_hold_days=int(variant["min_hold_days"]),
+    )
+
+
+def _fixed_ma_boll_candidate() -> Candidate:
+    return Candidate(
+        strategy="MA-BOLL-BANDS",
+        tol_pct=0.1,
+        buy_pct=0.5,
+        sell_pct=0.5,
+        bollinger_sigma=2.0,
+    )
+
+
+def _evaluate_period(
+    symbol: str,
+    candidate: Candidate,
+    data: Sequence[Sequence[Any]],
+    start: int,
+    end: int,
+    warmup_days: int,
+    slippage_bps: float,
+) -> dict[str, float | int]:
+    warmup_start = max(0, start - warmup_days)
+    return _evaluate_candidate(
+        symbol,
+        candidate,
+        data[start:end],
+        data[warmup_start:start],
+        slippage_bps,
+    )
+
+
+def _aggregate(metrics_by_asset: dict[str, dict[str, float | int]]) -> dict[str, Any]:
+    returns = [float(item["strategy_return"]) for item in metrics_by_asset.values()]
+    excess = [float(item["excess_return"]) for item in metrics_by_asset.values()]
+    transactions = [int(item["transactions"]) for item in metrics_by_asset.values()]
+    return {
+        "median_return": median(returns),
+        "median_excess_return": median(excess),
+        "positive_return_assets": sum(value > 0 for value in returns),
+        "positive_excess_assets": sum(value > 0 for value in excess),
+        "median_transactions": median(transactions),
+        "asset_count": len(metrics_by_asset),
+    }
+
+
+def run_validation(
+    symbols: Sequence[str],
+    train_days: int = 365,
+    validation_days: int = 90,
+    purge_days: int = 7,
+    warmup_days: int = 200,
+    slippage_bps: float = 10.0,
+) -> dict[str, Any]:
+    data_by_asset = {symbol: load_daily_data(symbol) for symbol in symbols}
+    minimum_rows = min(len(data) for data in data_by_asset.values())
+    test_start = train_days + validation_days + purge_days
+    if minimum_rows <= test_start:
+        raise ValueError("Not enough data for train/validation/purge/test split")
+
+    candidates = [_sma_candidate(variant) for variant in SMA200_VARIANTS]
+    candidate_results = []
+    for candidate in candidates:
+        train_by_asset = {}
+        validation_by_asset = {}
+        for symbol, data in data_by_asset.items():
+            train_by_asset[symbol] = _evaluate_period(
+                symbol,
+                candidate,
+                data,
+                0,
+                train_days,
+                warmup_days,
+                slippage_bps,
+            )
+            validation_by_asset[symbol] = _evaluate_period(
+                symbol,
+                candidate,
+                data,
+                train_days,
+                train_days + validation_days,
+                warmup_days,
+                slippage_bps,
+            )
+        candidate_results.append(
+            {
+                "candidate": candidate,
+                "train": _aggregate(train_by_asset),
+                "validation": _aggregate(validation_by_asset),
+                "train_by_asset": train_by_asset,
+                "validation_by_asset": validation_by_asset,
+            }
+        )
+
+    train_shortlist = sorted(
+        candidate_results,
+        key=lambda item: (
+            item["train"]["median_excess_return"],
+            item["train"]["median_return"],
+        ),
+        reverse=True,
+    )[:3]
+    selected = max(
+        train_shortlist,
+        key=lambda item: (
+            item["validation"]["median_excess_return"],
+            item["validation"]["median_return"],
+            -item["validation"]["median_transactions"],
+        ),
+    )["candidate"]
+
+    baseline = _sma_candidate(SMA200_BASELINE_VARIANT)
+    fixed_ma_boll = _fixed_ma_boll_candidate()
+    test_results = {}
+    for symbol, data in data_by_asset.items():
+        end = len(data)
+        test_results[symbol] = {
+            "data_start": data[0][1],
+            "data_end": data[-1][1],
+            "data_rows": len(data),
+            "test_start": data[test_start][1],
+            "test_end": data[-1][1],
+            "sma200_selected": _evaluate_period(
+                symbol,
+                selected,
+                data,
+                test_start,
+                end,
+                warmup_days,
+                slippage_bps,
+            ),
+            "sma200_baseline": _evaluate_period(
+                symbol,
+                baseline,
+                data,
+                test_start,
+                end,
+                warmup_days,
+                slippage_bps,
+            ),
+            "ma_boll_fixed": _evaluate_period(
+                symbol,
+                fixed_ma_boll,
+                data,
+                test_start,
+                end,
+                warmup_days,
+                slippage_bps,
+            ),
+        }
+
+    aggregate_test = {
+        name: _aggregate(
+            {symbol: result[name] for symbol, result in test_results.items()}
+        )
+        for name in ("sma200_selected", "sma200_baseline", "ma_boll_fixed")
+    }
+    return {
+        "configuration": {
+            "symbols": list(symbols),
+            "train_days": train_days,
+            "validation_days": validation_days,
+            "purge_days": purge_days,
+            "warmup_days": warmup_days,
+            "test_days": minimum_rows - test_start,
+            "execution_friction_rate": 0.02,
+            "slippage_bps": slippage_bps,
+            "signal_time": "daily_close",
+            "execution_time": "next_daily_open",
+            "options_enabled": False,
+            "selection_scope": "one shared variant across all assets",
+        },
+        "selected_sma200_candidate": asdict(selected),
+        "candidate_selection": [
+            {
+                "candidate": asdict(item["candidate"]),
+                "train": item["train"],
+                "validation": item["validation"],
+                "train_by_asset": item["train_by_asset"],
+                "validation_by_asset": item["validation_by_asset"],
+            }
+            for item in candidate_results
+        ],
+        "test_by_asset": test_results,
+        "aggregate_test": aggregate_test,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--symbols", nargs="+", default=["BTC", "ETH", "SOL"])
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+
+    report = run_validation(args.symbols)
+    output = args.output or Path("artifacts/backtests/sma200_variants_btc_eth_sol.json")
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(report, indent=2), encoding="utf-8")
+
+    print("Selected SMA200:", report["selected_sma200_candidate"])
+    for symbol, result in report["test_by_asset"].items():
+        selected = result["sma200_selected"]
+        baseline = result["sma200_baseline"]
+        ma_boll = result["ma_boll_fixed"]
+        print(
+            f"{symbol}: selected={selected['strategy_return']:.2f}%, "
+            f"baseline={baseline['strategy_return']:.2f}%, "
+            f"ma_boll={ma_boll['strategy_return']:.2f}%"
+        )
+    print("Aggregate:", report["aggregate_test"])
+    print(f"Saved report: {output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/app/backtesting/walk_forward.py
+++ b/app/backtesting/walk_forward.py
@@ -61,6 +61,9 @@ class Candidate:
     rsi_overbought: float | None = None
     kdj_oversold: float | None = None
     kdj_overbought: float | None = None
+    sma200_entry_band_pct: float = 0.0
+    sma200_exit_band_pct: float = 0.0
+    sma200_min_hold_days: int = 0
 
 
 def build_walk_forward_folds(
@@ -152,6 +155,13 @@ def _candidate_from_trader(trader: Any) -> Candidate:
         rsi_overbought=getattr(trader, "rsi_overbought", None),
         kdj_oversold=getattr(trader, "kdj_oversold", None),
         kdj_overbought=getattr(trader, "kdj_overbought", None),
+        sma200_entry_band_pct=float(
+            getattr(trader, "sma200_entry_band_pct", 0.0)
+        ),
+        sma200_exit_band_pct=float(
+            getattr(trader, "sma200_exit_band_pct", 0.0)
+        ),
+        sma200_min_hold_days=int(getattr(trader, "sma200_min_hold_days", 0)),
     )
 
 
@@ -215,6 +225,17 @@ def _driver_kwargs(
         "execute_on_next_open": True,
         "slippage_bps": slippage_bps,
         "enable_options": False,
+        "sma200_variants": (
+            [
+                {
+                    "entry_band_pct": candidate.sma200_entry_band_pct,
+                    "exit_band_pct": candidate.sma200_exit_band_pct,
+                    "min_hold_days": candidate.sma200_min_hold_days,
+                }
+            ]
+            if candidate and candidate.strategy == "SMA200"
+            else None
+        ),
     }
 
 

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -18,6 +18,7 @@ DEBUG = False
 # NOTE: We keep `STRATEGIES` as a backward-compatible alias to `CRYPTO_STRATEGIES` because many scripts/tests
 # pass it into `TraderDriver(overall_stats=...)`.
 SUPPORTED_STRATEGIES = [
+    "SMA200",
     "MA-SELVES",
     "MA-SELVES-MACRO",
     "EXP-MA-SELVES",
@@ -50,6 +51,7 @@ SUPPORTED_STRATEGIES = [
 # Enabled strategies (crypto)
 CRYPTO_STRATEGIES = [
     "MA-BOLL-BANDS",
+    "SMA200",
 ]
 
 # Enabled strategies (stocks) - daily candles only; keep separate from crypto

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -79,6 +79,10 @@ EMA_LENGTHS = [6, 12, 26, 30]
 BOLLINGER_MAS = [6, 12]
 BOLLINGER_TOLS = [2, 3, 4, 5]
 
+SMA200_VARIANTS = [
+    {"entry_band_pct": 0.05, "exit_band_pct": 0.05, "min_hold_days": 0},
+]
+
 # --- MA-BOLL-BANDS zoom-in configuration ---
 # When enabled, use intraday candles to refine actions during high-volatility regimes.
 MA_BOLL_ZOOM_IN = True

--- a/app/db/database.py
+++ b/app/db/database.py
@@ -333,21 +333,31 @@ class DatabaseManager:
         finally:
             db.close()
 
-    def get_data_statistics(self) -> List[Tuple[str, int, datetime]]:
+    def get_data_statistics(
+        self,
+    ) -> List[Tuple[str, int, datetime, datetime]]:
         """
-        Get statistics about cached data.
+        Get statistics from the historical price records.
 
         Returns:
-            List of (symbol, record_count, last_updated) tuples
+            List of (symbol, record_count, first_date, last_date) tuples.
         """
         try:
             db = SessionLocal()
 
-            stats = db.query(
-                DataCache.symbol, DataCache.data_count, DataCache.last_updated
-            ).all()
+            stats = (
+                db.query(
+                    HistoricalData.symbol,
+                    func.count(HistoricalData.id),
+                    func.min(HistoricalData.date),
+                    func.max(HistoricalData.date),
+                )
+                .group_by(HistoricalData.symbol)
+                .order_by(HistoricalData.symbol)
+                .all()
+            )
 
-            return [(stat.symbol, stat.data_count, stat.last_updated) for stat in stats]
+            return [(stat[0], int(stat[1]), stat[2], stat[3]) for stat in stats]
 
         except Exception as e:
             self.logger.error(f"Error getting data statistics: {e}")

--- a/app/db/db_management.py
+++ b/app/db/db_management.py
@@ -53,16 +53,18 @@ def show_statistics():
     try:
         stats = db_manager.get_data_statistics()
         if not stats:
-            print("No cached data found in database.")
+            print("No historical data found in database.")
             return
 
         print("\n=== Database Statistics ===")
-        print(f"{'Symbol':<15} {'Records':<10} {'Last Updated':<20}")
-        print("-" * 50)
+        print(f"{'Symbol':<20} {'Records':<10} {'First Date':<12} {'Last Date':<12}")
+        print("-" * 58)
 
-        for symbol, count, last_updated in stats:
+        for symbol, count, first_date, last_date in stats:
             print(
-                f"{symbol:<15} {count:<10} {last_updated.strftime('%Y-%m-%d %H:%M:%S')}"
+                f"{symbol:<20} {count:<10} "
+                f"{first_date.strftime('%Y-%m-%d'):<12} "
+                f"{last_date.strftime('%Y-%m-%d'):<12}"
             )
 
         print(f"\nTotal symbols: {len(stats)}")

--- a/app/trading/strat_trader.py
+++ b/app/trading/strat_trader.py
@@ -53,6 +53,9 @@ class StratTrader:
         execute_on_next_open: bool = False,
         slippage_bps: float = 0.0,
         enable_options: bool = True,
+        sma200_entry_band_pct: float = 0.0,
+        sma200_exit_band_pct: float = 0.0,
+        sma200_min_hold_days: int = 0,
         mode: str = "normal",
     ):
         """
@@ -154,6 +157,15 @@ class StratTrader:
         self.zoom_in = zoom_in
         self.zoom_in_min_move_pct = zoom_in_min_move_pct
         self.ma_boll_simplify = ma_boll_simplify
+        self.sma200_entry_band_pct = float(sma200_entry_band_pct)
+        self.sma200_exit_band_pct = float(sma200_exit_band_pct)
+        self.sma200_min_hold_days = int(sma200_min_hold_days)
+        if min(
+            self.sma200_entry_band_pct,
+            self.sma200_exit_band_pct,
+            self.sma200_min_hold_days,
+        ) < 0:
+            raise ValueError("SMA200 bands and minimum holding period cannot be negative")
         self.execute_on_next_open = execute_on_next_open
         self.slippage_bps = float(slippage_bps)
         if self.slippage_bps < 0:
@@ -225,6 +237,9 @@ class StratTrader:
                     trader=self,
                     new_p=new_p,
                     today=d,
+                    entry_band_pct=self.sma200_entry_band_pct,
+                    exit_band_pct=self.sma200_exit_band_pct,
+                    min_hold_days=self.sma200_min_hold_days,
                 )
 
             elif self.high_strategy == "MA-SELVES":
@@ -1211,4 +1226,12 @@ class StratTrader:
             "tol_pct": self.tol_pct,
             "bollinger_sigma": self.bollinger_sigma,
         }
+        if self.high_strategy == "SMA200":
+            basic.update(
+                {
+                    "sma200_entry_band_pct": self.sma200_entry_band_pct,
+                    "sma200_exit_band_pct": self.sma200_exit_band_pct,
+                    "sma200_min_hold_days": self.sma200_min_hold_days,
+                }
+            )
         return {**basic, **self.strategies}

--- a/app/trading/strat_trader.py
+++ b/app/trading/strat_trader.py
@@ -90,6 +90,9 @@ class StratTrader:
         # Enabled strategies differ between crypto vs stocks (see config.CRYPTO_STRATEGIES/STOCK_STRATEGIES).
         if stat not in SUPPORTED_STRATEGIES:
             raise ValueError("Unknown high-level trading strategy!")
+        ma_lengths = list(ma_lengths)
+        if stat == "SMA200" and 200 not in ma_lengths:
+            ma_lengths.append(200)
         if not all([x in ma_lengths for x in bollinger_mas]):
             raise ValueError(
                 "cannot initialize Bollinger Band strategy if some of moving averages are not available!"
@@ -127,7 +130,10 @@ class StratTrader:
         # 3. Trading Strategy
         # buy percentage (how much you want to invest) of your cash
         # sell percentage (how much you want to sell off) from your coin
-        self.buy_pct, self.sell_pct = buy_pct, sell_pct
+        if stat == "SMA200":
+            self.buy_pct, self.sell_pct = 1.0, 1.0
+        else:
+            self.buy_pct, self.sell_pct = buy_pct, sell_pct
         self.strategies = {"buy": buy_stas, "sell": sell_stas}
         # high-level strategy
         self.high_strategy = stat
@@ -214,7 +220,14 @@ class StratTrader:
         if self.high_strategy in STRATEGY_REGISTRY:
             strategy_func = STRATEGY_REGISTRY[self.high_strategy]
 
-            if self.high_strategy == "MA-SELVES":
+            if self.high_strategy == "SMA200":
+                strategy_func(
+                    trader=self,
+                    new_p=new_p,
+                    today=d,
+                )
+
+            elif self.high_strategy == "MA-SELVES":
                 for queue_name in self.moving_averages:
                     # if we don't have a moving average yet, skip
                     if self.moving_averages[queue_name][-1] is None:
@@ -483,7 +496,7 @@ class StratTrader:
             None
         """
         max_l = int(queue_name)
-        if len(self.crypto_prices) <= max_l:
+        if len(self.crypto_prices) < max_l:
             self.moving_averages[queue_name].append(None)
             return
         # compute new moving average, add it

--- a/app/trading/strategies.py
+++ b/app/trading/strategies.py
@@ -358,8 +358,11 @@ def strategy_sma200(
     trader,
     new_p: float,
     today: datetime.datetime,
+    entry_band_pct: float = 0.0,
+    exit_band_pct: float = 0.0,
+    min_hold_days: int = 0,
 ) -> Tuple[bool, bool]:
-    """Follow the long-term trend by holding above SMA200 and cash below it."""
+    """Hold above SMA200 with optional hysteresis bands and a minimum holding period."""
     strat_name = "SMA200"
     assert strat_name in STRATEGIES, "Unknown trading strategy name!"
 
@@ -370,13 +373,32 @@ def strategy_sma200(
     if last_sma is not None:
         has_cash = _is_positive_number(getattr(trader, "cash", 0))
         has_position = _is_positive_number(getattr(trader, "cur_coin", 0))
+        entry_threshold = last_sma * (1.0 + float(entry_band_pct))
+        exit_threshold = last_sma * (1.0 - float(exit_band_pct))
+        holding_period_satisfied = True
 
-        if new_p > last_sma and has_cash:
+        if has_position and int(min_hold_days) > 0:
+            for item in reversed(getattr(trader, "trade_history", [])):
+                if item.get("action") != BUY_SIGNAL:
+                    continue
+                buy_date = item.get("date")
+                try:
+                    held_days = (today.date() - buy_date.date()).days
+                except AttributeError:
+                    held_days = (today - buy_date).days
+                holding_period_satisfied = held_days >= int(min_hold_days)
+                break
+
+        if new_p > entry_threshold and has_cash:
             r_buy = trader._execute_one_buy("by_percentage", new_p)
             if r_buy:
                 trader._record_history(new_p, today, BUY_SIGNAL)
                 trader.strat_dct[strat_name].append((today, BUY_SIGNAL))
-        elif new_p < last_sma and has_position:
+        elif (
+            new_p < exit_threshold
+            and has_position
+            and holding_period_satisfied
+        ):
             r_sell = trader._execute_one_sell("by_percentage", new_p)
             if r_sell:
                 trader._record_history(new_p, today, SELL_SIGNAL)

--- a/app/trading/strategies.py
+++ b/app/trading/strategies.py
@@ -354,6 +354,41 @@ def strategy_moving_average_w_tolerance(
     return r_buy, r_sell
 
 
+def strategy_sma200(
+    trader,
+    new_p: float,
+    today: datetime.datetime,
+) -> Tuple[bool, bool]:
+    """Follow the long-term trend by holding above SMA200 and cash below it."""
+    strat_name = "SMA200"
+    assert strat_name in STRATEGIES, "Unknown trading strategy name!"
+
+    sma_values = getattr(trader, "moving_averages", {}).get("200", [])
+    last_sma = sma_values[-1] if sma_values else None
+    r_buy, r_sell = False, False
+
+    if last_sma is not None:
+        has_cash = _is_positive_number(getattr(trader, "cash", 0))
+        has_position = _is_positive_number(getattr(trader, "cur_coin", 0))
+
+        if new_p > last_sma and has_cash:
+            r_buy = trader._execute_one_buy("by_percentage", new_p)
+            if r_buy:
+                trader._record_history(new_p, today, BUY_SIGNAL)
+                trader.strat_dct[strat_name].append((today, BUY_SIGNAL))
+        elif new_p < last_sma and has_position:
+            r_sell = trader._execute_one_sell("by_percentage", new_p)
+            if r_sell:
+                trader._record_history(new_p, today, SELL_SIGNAL)
+                trader.strat_dct[strat_name].append((today, SELL_SIGNAL))
+
+    if not r_buy and not r_sell:
+        trader._record_history(new_p, today, NO_ACTION_SIGNAL)
+        trader.strat_dct[strat_name].append((today, NO_ACTION_SIGNAL))
+
+    return r_buy, r_sell
+
+
 def strategy_double_moving_averages(
     trader,
     shorter_queue_name: str,
@@ -4251,6 +4286,7 @@ def strategy_adaptive_ma_selves_macro_enhanced(
 # ---- Strategy registry for easy lookup ---- #
 STRATEGY_REGISTRY = {
     "ECONOMIC-INDICATORS": EconomicIndicatorsStrategy,
+    "SMA200": strategy_sma200,
     "MA-SELVES": strategy_moving_average_w_tolerance,
     "MA-SELVES-MACRO": strategy_ma_selves_macro_enhanced,
     "EXP-MA-SELVES": strategy_exponential_moving_average_w_tolerance,

--- a/app/trading/trader_driver.py
+++ b/app/trading/trader_driver.py
@@ -16,6 +16,7 @@ from app.core.config import (
     RSI_OVERBOUGHT_THRESHOLDS,
     RSI_OVERSOLD_THRESHOLDS,
     RSI_PERIODS,
+    SMA200_VARIANTS,
 )
 from app.trading.strat_trader import StratTrader
 from app.utils.util import timer
@@ -47,19 +48,13 @@ class TraderDriver:
         rsi_overbought_thresholds: List[float],
         kdj_oversold_thresholds: List[float],
         kdj_overbought_thresholds: List[float],
+        sma200_variants: Optional[List[Dict[str, Any]]] = None,
     ) -> int:
         """
         Compute the expected number of StratTrader instances given parameter grids.
 
         This is useful for sanity-checking narrowed grids (e.g., moving-window auto-tuning).
         """
-        base = (
-            len(bollinger_tols)
-            * len(overall_stats)
-            * len(tol_pcts)
-            * len(buy_pcts)
-            * len(sell_pcts)
-        )
 
         # Adjust for strategies that expand the grid (RSI/KDJ)
         # Our unified grid counts RSI/KDJ once each; replace that "1" with their extra grid sizes.
@@ -77,8 +72,12 @@ class TraderDriver:
         # For each of bollinger_sigma/tol/buy/sell combination, total traders equals:
         # sum over strategies of (extra_grid_size_for_strategy)
         per_combo = 0
+        fixed_strategy_count = 0
+        configured_sma200_variants = sma200_variants or SMA200_VARIANTS
         for s in overall_stats:
-            if s == "RSI":
+            if s == "SMA200":
+                fixed_strategy_count += len(configured_sma200_variants)
+            elif s == "RSI":
                 per_combo += max(1, rsi_extra)
             elif s == "KDJ":
                 per_combo += max(1, kdj_extra)
@@ -88,7 +87,7 @@ class TraderDriver:
         combos_without_strategy = (
             len(bollinger_tols) * len(tol_pcts) * len(buy_pcts) * len(sell_pcts)
         )
-        return combos_without_strategy * per_combo
+        return fixed_strategy_count + combos_without_strategy * per_combo
 
     @staticmethod
     def _strategy_extra_param_grid(
@@ -138,6 +137,7 @@ class TraderDriver:
         rsi_overbought_thresholds: List[float],
         kdj_oversold_thresholds: List[float],
         kdj_overbought_thresholds: List[float],
+        sma200_variants: Optional[List[Dict[str, Any]]] = None,
     ) -> Iterable[Dict[str, Any]]:
         """
         Yield dicts of parameters that define a unique StratTrader instance.
@@ -145,26 +145,42 @@ class TraderDriver:
         This is intentionally strategy-agnostic: strategies are handled by providing an
         (optional) extra param grid per strategy.
         """
-        for bollinger_sigma, stat, tol_pct, buy_pct, sell_pct in product(
-            bollinger_tols, overall_stats, tol_pcts, buy_pcts, sell_pcts
-        ):
-            extras = cls._strategy_extra_param_grid(
-                stat,
-                rsi_periods=rsi_periods,
-                rsi_oversold_thresholds=rsi_oversold_thresholds,
-                rsi_overbought_thresholds=rsi_overbought_thresholds,
-                kdj_oversold_thresholds=kdj_oversold_thresholds,
-                kdj_overbought_thresholds=kdj_overbought_thresholds,
-            )
-            for extra in extras:
-                yield {
-                    "stat": stat,
-                    "tol_pct": tol_pct,
-                    "buy_pct": buy_pct,
-                    "sell_pct": sell_pct,
-                    "bollinger_sigma": bollinger_sigma,
-                    **extra,
-                }
+        configured_sma200_variants = sma200_variants or SMA200_VARIANTS
+        for stat in overall_stats:
+            if stat == "SMA200":
+                for variant in configured_sma200_variants:
+                    yield {
+                        "stat": stat,
+                        "tol_pct": 0.0,
+                        "buy_pct": 1.0,
+                        "sell_pct": 1.0,
+                        "bollinger_sigma": bollinger_tols[0] if bollinger_tols else 2,
+                        "sma200_entry_band_pct": float(variant["entry_band_pct"]),
+                        "sma200_exit_band_pct": float(variant["exit_band_pct"]),
+                        "sma200_min_hold_days": int(variant["min_hold_days"]),
+                    }
+                continue
+
+            for bollinger_sigma, tol_pct, buy_pct, sell_pct in product(
+                bollinger_tols, tol_pcts, buy_pcts, sell_pcts
+            ):
+                extras = cls._strategy_extra_param_grid(
+                    stat,
+                    rsi_periods=rsi_periods,
+                    rsi_oversold_thresholds=rsi_oversold_thresholds,
+                    rsi_overbought_thresholds=rsi_overbought_thresholds,
+                    kdj_oversold_thresholds=kdj_oversold_thresholds,
+                    kdj_overbought_thresholds=kdj_overbought_thresholds,
+                )
+                for extra in extras:
+                    yield {
+                        "stat": stat,
+                        "tol_pct": tol_pct,
+                        "buy_pct": buy_pct,
+                        "sell_pct": sell_pct,
+                        "bollinger_sigma": bollinger_sigma,
+                        **extra,
+                    }
 
     def __init__(
         self,
@@ -192,6 +208,7 @@ class TraderDriver:
         execute_on_next_open: bool = False,
         slippage_bps: float = 0.0,
         enable_options: bool = True,
+        sma200_variants: Optional[List[Dict[str, Any]]] = None,
         mode: str = "normal",
     ):
         """
@@ -234,6 +251,7 @@ class TraderDriver:
             rsi_overbought_thresholds=rsi_overbought_thresholds,
             kdj_oversold_thresholds=kdj_oversold_thresholds,
             kdj_overbought_thresholds=kdj_overbought_thresholds,
+            sma200_variants=sma200_variants,
         ):
             t = StratTrader(
                 name=name,
@@ -262,6 +280,9 @@ class TraderDriver:
                 execute_on_next_open=execute_on_next_open,
                 slippage_bps=slippage_bps,
                 enable_options=enable_options,
+                sma200_entry_band_pct=spec.get("sma200_entry_band_pct", 0.0),
+                sma200_exit_band_pct=spec.get("sma200_exit_band_pct", 0.0),
+                sma200_min_hold_days=spec.get("sma200_min_hold_days", 0),
             )
             self.traders.append(t)
 
@@ -276,6 +297,7 @@ class TraderDriver:
             rsi_overbought_thresholds=rsi_overbought_thresholds,
             kdj_oversold_thresholds=kdj_oversold_thresholds,
             kdj_overbought_thresholds=kdj_overbought_thresholds,
+            sma200_variants=sma200_variants,
         )
         if len(self.traders) != expected:
             logger.warning(

--- a/artifacts/backtests/sma200_variants_btc_eth_sol.json
+++ b/artifacts/backtests/sma200_variants_btc_eth_sol.json
@@ -1,0 +1,623 @@
+{
+  "configuration": {
+    "symbols": [
+      "BTC",
+      "ETH",
+      "SOL"
+    ],
+    "train_days": 365,
+    "validation_days": 90,
+    "purge_days": 7,
+    "warmup_days": 200,
+    "test_days": 633,
+    "execution_friction_rate": 0.02,
+    "slippage_bps": 10.0,
+    "signal_time": "daily_close",
+    "execution_time": "next_daily_open",
+    "options_enabled": false,
+    "selection_scope": "one shared variant across all assets"
+  },
+  "selected_sma200_candidate": {
+    "strategy": "SMA200",
+    "tol_pct": 0.0,
+    "buy_pct": 1.0,
+    "sell_pct": 1.0,
+    "bollinger_sigma": 2.0,
+    "rsi_period": null,
+    "rsi_oversold": null,
+    "rsi_overbought": null,
+    "kdj_oversold": null,
+    "kdj_overbought": null,
+    "sma200_entry_band_pct": 0.05,
+    "sma200_exit_band_pct": 0.05,
+    "sma200_min_hold_days": 0
+  },
+  "candidate_selection": [
+    {
+      "candidate": {
+        "strategy": "SMA200",
+        "tol_pct": 0.0,
+        "buy_pct": 1.0,
+        "sell_pct": 1.0,
+        "bollinger_sigma": 2.0,
+        "rsi_period": null,
+        "rsi_oversold": null,
+        "rsi_overbought": null,
+        "kdj_oversold": null,
+        "kdj_overbought": null,
+        "sma200_entry_band_pct": 0.0,
+        "sma200_exit_band_pct": 0.0,
+        "sma200_min_hold_days": 0
+      },
+      "train": {
+        "median_return": -9.312,
+        "median_excess_return": -103.82791585935146,
+        "positive_return_assets": 1,
+        "positive_excess_assets": 0,
+        "median_transactions": 6,
+        "asset_count": 3
+      },
+      "validation": {
+        "median_return": -14.087,
+        "median_excess_return": -29.893157666835418,
+        "positive_return_assets": 0,
+        "positive_excess_assets": 1,
+        "median_transactions": 7,
+        "asset_count": 3
+      },
+      "train_by_asset": {
+        "BTC": {
+          "strategy_return": 7.405,
+          "buy_hold_return": 111.23291585935146,
+          "excess_return": -103.82791585935146,
+          "max_drawdown": 23.56,
+          "transactions": 3
+        },
+        "ETH": {
+          "strategy_return": -9.312,
+          "buy_hold_return": 63.34613682433356,
+          "excess_return": -72.65813682433357,
+          "max_drawdown": 32.89,
+          "transactions": 6
+        },
+        "SOL": {
+          "strategy_return": -12.665,
+          "buy_hold_return": 570.0438596491229,
+          "excess_return": -582.7088596491228,
+          "max_drawdown": 54.35,
+          "transactions": 9
+        }
+      },
+      "validation_by_asset": {
+        "BTC": {
+          "strategy_return": -14.087,
+          "buy_hold_return": 15.806157666835418,
+          "excess_return": -29.893157666835418,
+          "max_drawdown": 18.52,
+          "transactions": 7
+        },
+        "ETH": {
+          "strategy_return": 0.0,
+          "buy_hold_return": -13.260252648399929,
+          "excess_return": 13.260252648399929,
+          "max_drawdown": 0.0,
+          "transactions": 0
+        },
+        "SOL": {
+          "strategy_return": -29.986,
+          "buy_hold_return": 18.36233511086163,
+          "excess_return": -48.348335110861626,
+          "max_drawdown": 34.32,
+          "transactions": 9
+        }
+      }
+    },
+    {
+      "candidate": {
+        "strategy": "SMA200",
+        "tol_pct": 0.0,
+        "buy_pct": 1.0,
+        "sell_pct": 1.0,
+        "bollinger_sigma": 2.0,
+        "rsi_period": null,
+        "rsi_oversold": null,
+        "rsi_overbought": null,
+        "kdj_oversold": null,
+        "kdj_overbought": null,
+        "sma200_entry_band_pct": 0.02,
+        "sma200_exit_band_pct": 0.02,
+        "sma200_min_hold_days": 0
+      },
+      "train": {
+        "median_return": -7.444,
+        "median_excess_return": -106.64291585935146,
+        "positive_return_assets": 1,
+        "positive_excess_assets": 0,
+        "median_transactions": 3,
+        "asset_count": 3
+      },
+      "validation": {
+        "median_return": -6.879,
+        "median_excess_return": -22.685157666835416,
+        "positive_return_assets": 0,
+        "positive_excess_assets": 1,
+        "median_transactions": 3,
+        "asset_count": 3
+      },
+      "train_by_asset": {
+        "BTC": {
+          "strategy_return": 4.59,
+          "buy_hold_return": 111.23291585935146,
+          "excess_return": -106.64291585935146,
+          "max_drawdown": 24.310000000000002,
+          "transactions": 3
+        },
+        "ETH": {
+          "strategy_return": -12.467,
+          "buy_hold_return": 63.34613682433356,
+          "excess_return": -75.81313682433357,
+          "max_drawdown": 31.2,
+          "transactions": 3
+        },
+        "SOL": {
+          "strategy_return": -7.444,
+          "buy_hold_return": 570.0438596491229,
+          "excess_return": -577.4878596491228,
+          "max_drawdown": 53.73,
+          "transactions": 7
+        }
+      },
+      "validation_by_asset": {
+        "BTC": {
+          "strategy_return": -6.879,
+          "buy_hold_return": 15.806157666835418,
+          "excess_return": -22.685157666835416,
+          "max_drawdown": 11.68,
+          "transactions": 3
+        },
+        "ETH": {
+          "strategy_return": 0.0,
+          "buy_hold_return": -13.260252648399929,
+          "excess_return": 13.260252648399929,
+          "max_drawdown": 0.0,
+          "transactions": 0
+        },
+        "SOL": {
+          "strategy_return": -33.004,
+          "buy_hold_return": 18.36233511086163,
+          "excess_return": -51.36633511086163,
+          "max_drawdown": 40.23,
+          "transactions": 7
+        }
+      }
+    },
+    {
+      "candidate": {
+        "strategy": "SMA200",
+        "tol_pct": 0.0,
+        "buy_pct": 1.0,
+        "sell_pct": 1.0,
+        "bollinger_sigma": 2.0,
+        "rsi_period": null,
+        "rsi_oversold": null,
+        "rsi_overbought": null,
+        "kdj_oversold": null,
+        "kdj_overbought": null,
+        "sma200_entry_band_pct": 0.03,
+        "sma200_exit_band_pct": 0.03,
+        "sma200_min_hold_days": 0
+      },
+      "train": {
+        "median_return": -12.467,
+        "median_excess_return": -113.71291585935147,
+        "positive_return_assets": 0,
+        "positive_excess_assets": 0,
+        "median_transactions": 3,
+        "asset_count": 3
+      },
+      "validation": {
+        "median_return": -7.722,
+        "median_excess_return": -23.52815766683542,
+        "positive_return_assets": 0,
+        "positive_excess_assets": 1,
+        "median_transactions": 3,
+        "asset_count": 3
+      },
+      "train_by_asset": {
+        "BTC": {
+          "strategy_return": -2.48,
+          "buy_hold_return": 111.23291585935146,
+          "excess_return": -113.71291585935147,
+          "max_drawdown": 29.42,
+          "transactions": 3
+        },
+        "ETH": {
+          "strategy_return": -12.467,
+          "buy_hold_return": 63.34613682433356,
+          "excess_return": -75.81313682433357,
+          "max_drawdown": 31.2,
+          "transactions": 3
+        },
+        "SOL": {
+          "strategy_return": -19.13,
+          "buy_hold_return": 570.0438596491229,
+          "excess_return": -589.1738596491228,
+          "max_drawdown": 55.06999999999999,
+          "transactions": 7
+        }
+      },
+      "validation_by_asset": {
+        "BTC": {
+          "strategy_return": -7.722,
+          "buy_hold_return": 15.806157666835418,
+          "excess_return": -23.52815766683542,
+          "max_drawdown": 12.479999999999999,
+          "transactions": 3
+        },
+        "ETH": {
+          "strategy_return": 0.0,
+          "buy_hold_return": -13.260252648399929,
+          "excess_return": 13.260252648399929,
+          "max_drawdown": 0.0,
+          "transactions": 0
+        },
+        "SOL": {
+          "strategy_return": -23.672,
+          "buy_hold_return": 18.36233511086163,
+          "excess_return": -42.03433511086163,
+          "max_drawdown": 31.900000000000002,
+          "transactions": 5
+        }
+      }
+    },
+    {
+      "candidate": {
+        "strategy": "SMA200",
+        "tol_pct": 0.0,
+        "buy_pct": 1.0,
+        "sell_pct": 1.0,
+        "bollinger_sigma": 2.0,
+        "rsi_period": null,
+        "rsi_oversold": null,
+        "rsi_overbought": null,
+        "kdj_oversold": null,
+        "kdj_overbought": null,
+        "sma200_entry_band_pct": 0.05,
+        "sma200_exit_band_pct": 0.05,
+        "sma200_min_hold_days": 0
+      },
+      "train": {
+        "median_return": 11.291,
+        "median_excess_return": -94.94391585935146,
+        "positive_return_assets": 2,
+        "positive_excess_assets": 0,
+        "median_transactions": 3,
+        "asset_count": 3
+      },
+      "validation": {
+        "median_return": 0.0,
+        "median_excess_return": -13.207157666835418,
+        "positive_return_assets": 1,
+        "positive_excess_assets": 1,
+        "median_transactions": 1,
+        "asset_count": 3
+      },
+      "train_by_asset": {
+        "BTC": {
+          "strategy_return": 16.289,
+          "buy_hold_return": 111.23291585935146,
+          "excess_return": -94.94391585935146,
+          "max_drawdown": 23.56,
+          "transactions": 1
+        },
+        "ETH": {
+          "strategy_return": -19.838,
+          "buy_hold_return": 63.34613682433356,
+          "excess_return": -83.18413682433356,
+          "max_drawdown": 36.99,
+          "transactions": 3
+        },
+        "SOL": {
+          "strategy_return": 11.291,
+          "buy_hold_return": 570.0438596491229,
+          "excess_return": -558.7528596491228,
+          "max_drawdown": 38.17,
+          "transactions": 3
+        }
+      },
+      "validation_by_asset": {
+        "BTC": {
+          "strategy_return": 2.599,
+          "buy_hold_return": 15.806157666835418,
+          "excess_return": -13.207157666835418,
+          "max_drawdown": 3.42,
+          "transactions": 1
+        },
+        "ETH": {
+          "strategy_return": 0.0,
+          "buy_hold_return": -13.260252648399929,
+          "excess_return": 13.260252648399929,
+          "max_drawdown": 0.0,
+          "transactions": 0
+        },
+        "SOL": {
+          "strategy_return": -27.483,
+          "buy_hold_return": 18.36233511086163,
+          "excess_return": -45.845335110861626,
+          "max_drawdown": 29.84,
+          "transactions": 5
+        }
+      }
+    },
+    {
+      "candidate": {
+        "strategy": "SMA200",
+        "tol_pct": 0.0,
+        "buy_pct": 1.0,
+        "sell_pct": 1.0,
+        "bollinger_sigma": 2.0,
+        "rsi_period": null,
+        "rsi_oversold": null,
+        "rsi_overbought": null,
+        "kdj_oversold": null,
+        "kdj_overbought": null,
+        "sma200_entry_band_pct": 0.03,
+        "sma200_exit_band_pct": 0.03,
+        "sma200_min_hold_days": 14
+      },
+      "train": {
+        "median_return": -2.48,
+        "median_excess_return": -113.71291585935147,
+        "positive_return_assets": 1,
+        "positive_excess_assets": 0,
+        "median_transactions": 3,
+        "asset_count": 3
+      },
+      "validation": {
+        "median_return": 0.0,
+        "median_excess_return": -11.173157666835419,
+        "positive_return_assets": 1,
+        "positive_excess_assets": 1,
+        "median_transactions": 1,
+        "asset_count": 3
+      },
+      "train_by_asset": {
+        "BTC": {
+          "strategy_return": -2.48,
+          "buy_hold_return": 111.23291585935146,
+          "excess_return": -113.71291585935147,
+          "max_drawdown": 29.42,
+          "transactions": 3
+        },
+        "ETH": {
+          "strategy_return": -12.467,
+          "buy_hold_return": 63.34613682433356,
+          "excess_return": -75.81313682433357,
+          "max_drawdown": 31.2,
+          "transactions": 3
+        },
+        "SOL": {
+          "strategy_return": 10.48,
+          "buy_hold_return": 570.0438596491229,
+          "excess_return": -559.5638596491228,
+          "max_drawdown": 47.97,
+          "transactions": 3
+        }
+      },
+      "validation_by_asset": {
+        "BTC": {
+          "strategy_return": 4.633,
+          "buy_hold_return": 15.806157666835418,
+          "excess_return": -11.173157666835419,
+          "max_drawdown": 10.2,
+          "transactions": 1
+        },
+        "ETH": {
+          "strategy_return": 0.0,
+          "buy_hold_return": -13.260252648399929,
+          "excess_return": 13.260252648399929,
+          "max_drawdown": 0.0,
+          "transactions": 0
+        },
+        "SOL": {
+          "strategy_return": -9.615,
+          "buy_hold_return": 18.36233511086163,
+          "excess_return": -27.97733511086163,
+          "max_drawdown": 19.36,
+          "transactions": 3
+        }
+      }
+    },
+    {
+      "candidate": {
+        "strategy": "SMA200",
+        "tol_pct": 0.0,
+        "buy_pct": 1.0,
+        "sell_pct": 1.0,
+        "bollinger_sigma": 2.0,
+        "rsi_period": null,
+        "rsi_oversold": null,
+        "rsi_overbought": null,
+        "kdj_oversold": null,
+        "kdj_overbought": null,
+        "sma200_entry_band_pct": 0.03,
+        "sma200_exit_band_pct": 0.03,
+        "sma200_min_hold_days": 30
+      },
+      "train": {
+        "median_return": -2.48,
+        "median_excess_return": -113.71291585935147,
+        "positive_return_assets": 1,
+        "positive_excess_assets": 0,
+        "median_transactions": 3,
+        "asset_count": 3
+      },
+      "validation": {
+        "median_return": 0.0,
+        "median_excess_return": -11.173157666835419,
+        "positive_return_assets": 1,
+        "positive_excess_assets": 1,
+        "median_transactions": 1,
+        "asset_count": 3
+      },
+      "train_by_asset": {
+        "BTC": {
+          "strategy_return": -2.48,
+          "buy_hold_return": 111.23291585935146,
+          "excess_return": -113.71291585935147,
+          "max_drawdown": 29.42,
+          "transactions": 3
+        },
+        "ETH": {
+          "strategy_return": -12.467,
+          "buy_hold_return": 63.34613682433356,
+          "excess_return": -75.81313682433357,
+          "max_drawdown": 35.23,
+          "transactions": 3
+        },
+        "SOL": {
+          "strategy_return": 10.48,
+          "buy_hold_return": 570.0438596491229,
+          "excess_return": -559.5638596491228,
+          "max_drawdown": 47.97,
+          "transactions": 3
+        }
+      },
+      "validation_by_asset": {
+        "BTC": {
+          "strategy_return": 4.633,
+          "buy_hold_return": 15.806157666835418,
+          "excess_return": -11.173157666835419,
+          "max_drawdown": 10.2,
+          "transactions": 1
+        },
+        "ETH": {
+          "strategy_return": 0.0,
+          "buy_hold_return": -13.260252648399929,
+          "excess_return": 13.260252648399929,
+          "max_drawdown": 0.0,
+          "transactions": 0
+        },
+        "SOL": {
+          "strategy_return": -19.856,
+          "buy_hold_return": 18.36233511086163,
+          "excess_return": -38.21833511086163,
+          "max_drawdown": 28.499999999999996,
+          "transactions": 3
+        }
+      }
+    }
+  ],
+  "test_by_asset": {
+    "BTC": {
+      "data_start": "2023-08-04 00:00:00",
+      "data_end": "2026-08-02 00:00:00",
+      "data_rows": 1095,
+      "test_start": "2024-11-08 00:00:00",
+      "test_end": "2026-08-02 00:00:00",
+      "sma200_selected": {
+        "strategy_return": 2.508,
+        "buy_hold_return": -16.91258294037703,
+        "excess_return": 19.420582940377027,
+        "max_drawdown": 28.84,
+        "transactions": 4
+      },
+      "sma200_baseline": {
+        "strategy_return": -29.525,
+        "buy_hold_return": -16.91258294037703,
+        "excess_return": -12.61241705962297,
+        "max_drawdown": 48.11,
+        "transactions": 18
+      },
+      "ma_boll_fixed": {
+        "strategy_return": -41.882,
+        "buy_hold_return": -16.91258294037703,
+        "excess_return": -24.96941705962297,
+        "max_drawdown": 45.69,
+        "transactions": 86
+      }
+    },
+    "ETH": {
+      "data_start": "2023-08-04 00:00:00",
+      "data_end": "2026-08-02 00:00:00",
+      "data_rows": 1095,
+      "test_start": "2024-11-08 00:00:00",
+      "test_end": "2026-08-02 00:00:00",
+      "sma200_selected": {
+        "strategy_return": -18.778,
+        "buy_hold_return": -36.34304043217692,
+        "excess_return": 17.56504043217692,
+        "max_drawdown": 45.31,
+        "transactions": 6
+      },
+      "sma200_baseline": {
+        "strategy_return": -17.283,
+        "buy_hold_return": -36.34304043217692,
+        "excess_return": 19.06004043217692,
+        "max_drawdown": 46.400000000000006,
+        "transactions": 14
+      },
+      "ma_boll_fixed": {
+        "strategy_return": -34.318,
+        "buy_hold_return": -36.34304043217692,
+        "excess_return": 2.0250404321769224,
+        "max_drawdown": 43.87,
+        "transactions": 121
+      }
+    },
+    "SOL": {
+      "data_start": "2023-08-04 00:00:00",
+      "data_end": "2026-08-02 00:00:00",
+      "data_rows": 1095,
+      "test_start": "2024-11-08 00:00:00",
+      "test_end": "2026-08-02 00:00:00",
+      "sma200_selected": {
+        "strategy_return": -25.559,
+        "buy_hold_return": -63.157368026019526,
+        "excess_return": 37.59836802601953,
+        "max_drawdown": 43.45,
+        "transactions": 4
+      },
+      "sma200_baseline": {
+        "strategy_return": -31.783,
+        "buy_hold_return": -63.157368026019526,
+        "excess_return": 31.374368026019525,
+        "max_drawdown": 46.839999999999996,
+        "transactions": 8
+      },
+      "ma_boll_fixed": {
+        "strategy_return": -52.948,
+        "buy_hold_return": -63.157368026019526,
+        "excess_return": 10.209368026019526,
+        "max_drawdown": 56.88999999999999,
+        "transactions": 132
+      }
+    }
+  },
+  "aggregate_test": {
+    "sma200_selected": {
+      "median_return": -18.778,
+      "median_excess_return": 19.420582940377027,
+      "positive_return_assets": 1,
+      "positive_excess_assets": 3,
+      "median_transactions": 4,
+      "asset_count": 3
+    },
+    "sma200_baseline": {
+      "median_return": -29.525,
+      "median_excess_return": 19.06004043217692,
+      "positive_return_assets": 0,
+      "positive_excess_assets": 2,
+      "median_transactions": 14,
+      "asset_count": 3
+    },
+    "ma_boll_fixed": {
+      "median_return": -41.882,
+      "median_excess_return": 2.0250404321769224,
+      "positive_return_assets": 0,
+      "positive_excess_assets": 2,
+      "median_transactions": 121,
+      "asset_count": 3
+    }
+  }
+}

--- a/tests/db/test_database_statistics.py
+++ b/tests/db/test_database_statistics.py
@@ -1,0 +1,49 @@
+from datetime import datetime
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.db import database
+
+
+def test_statistics_are_derived_from_historical_records(tmp_path, monkeypatch):
+    engine = create_engine(f"sqlite:///{tmp_path / 'statistics.db'}")
+    database.Base.metadata.create_all(bind=engine)
+    test_session = sessionmaker(bind=engine)
+
+    with test_session() as session:
+        session.add_all(
+            [
+                database.HistoricalData(
+                    symbol="BTCUSDT__1d",
+                    date=datetime(2023, 8, 4),
+                    open_price=1,
+                    high_price=2,
+                    low_price=0.5,
+                    close_price=1.5,
+                    volume=10,
+                ),
+                database.HistoricalData(
+                    symbol="BTCUSDT__1d",
+                    date=datetime(2026, 8, 2),
+                    open_price=2,
+                    high_price=3,
+                    low_price=1.5,
+                    close_price=2.5,
+                    volume=20,
+                ),
+            ]
+        )
+        session.commit()
+        assert session.query(database.DataCache).count() == 0
+
+    monkeypatch.setattr(database, "SessionLocal", test_session)
+
+    assert database.db_manager.get_data_statistics() == [
+        (
+            "BTCUSDT__1d",
+            2,
+            datetime(2023, 8, 4),
+            datetime(2026, 8, 2),
+        )
+    ]

--- a/tests/strategy/test_ma_boll_bands_strategy.py
+++ b/tests/strategy/test_ma_boll_bands_strategy.py
@@ -25,8 +25,10 @@ def create_mock_trader():
 
     trader.strat_dct = {"MA-BOLL-BANDS": []}
     trader.moving_averages = {"6": []}
+    trader.crypto_prices = []
     trader.cash = 10000.0
     trader.cur_coin = 0.0
+    trader.portfolio_value = 10000.0
 
     return trader
 

--- a/tests/strategy/test_sma200_strategy.py
+++ b/tests/strategy/test_sma200_strategy.py
@@ -1,0 +1,89 @@
+from datetime import datetime, timedelta
+
+import pytest
+
+from app.core.config import BUY_SIGNAL, SELL_SIGNAL, SUPPORTED_STRATEGIES
+from app.trading.strat_trader import StratTrader
+from app.trading.strategies import STRATEGY_REGISTRY
+
+
+def _trader(**overrides):
+    kwargs = {
+        "name": "BTC",
+        "init_amount": 10_000,
+        "stat": "SMA200",
+        "tol_pct": 0.1,
+        "ma_lengths": [6, 12, 30],
+        "ema_lengths": [6, 12, 26, 30],
+        "bollinger_mas": [6, 12],
+        "bollinger_sigma": 2,
+        "buy_pct": 0.25,
+        "sell_pct": 0.25,
+    }
+    kwargs.update(overrides)
+    return StratTrader(**kwargs)
+
+
+def _add_day(trader, index, close, open_price=None, execute_strategy=True):
+    day = datetime(2024, 1, 1) + timedelta(days=index)
+    open_price = close if open_price is None else open_price
+    trader.add_new_day(
+        new_p=close,
+        d=day,
+        misc_p={
+            "open": open_price,
+            "low": min(open_price, close) - 1,
+            "high": max(open_price, close) + 1,
+            "volume": 1000,
+        },
+        execute_strategy=execute_strategy,
+    )
+
+
+def test_sma200_is_registered_and_adds_required_average():
+    trader = _trader()
+
+    assert "SMA200" in SUPPORTED_STRATEGIES
+    assert STRATEGY_REGISTRY["SMA200"] is not None
+    assert "200" in trader.moving_averages
+    assert trader.buy_pct == 1.0
+    assert trader.sell_pct == 1.0
+
+
+def test_sma200_goes_all_in_above_average_and_exits_below_it():
+    trader = _trader()
+    for index in range(199):
+        _add_day(trader, index, 100, execute_strategy=False)
+
+    _add_day(trader, 199, 110)
+
+    assert trader.moving_averages["200"][-1] == pytest.approx(100.05)
+    assert trader.cash == 0
+    assert trader.cur_coin == pytest.approx(10_000 * 0.98 / 110)
+    assert trader.trade_history[-1]["action"] == BUY_SIGNAL
+
+    _add_day(trader, 200, 90)
+
+    assert trader.cur_coin == 0
+    assert trader.trade_history[-1]["action"] == SELL_SIGNAL
+
+
+def test_sma200_signal_executes_at_next_open_when_enabled():
+    trader = _trader(execute_on_next_open=True, slippage_bps=10)
+    for index in range(199):
+        _add_day(trader, index, 100, execute_strategy=False)
+
+    _add_day(trader, 199, 110)
+
+    assert trader.cur_coin == 0
+    assert trader.pending_order["action"] == BUY_SIGNAL
+
+    _add_day(trader, 200, 110, open_price=105)
+
+    expected_quantity = 10_000 * 0.98 / 105.105
+    assert trader.cash == 0
+    assert trader.cur_coin == pytest.approx(expected_quantity)
+    buy_trade = next(
+        item for item in trader.trade_history if item["action"] == BUY_SIGNAL
+    )
+    assert buy_trade["price"] == pytest.approx(105.105)

--- a/tests/strategy/test_sma200_strategy.py
+++ b/tests/strategy/test_sma200_strategy.py
@@ -2,9 +2,15 @@ from datetime import datetime, timedelta
 
 import pytest
 
-from app.core.config import BUY_SIGNAL, SELL_SIGNAL, SUPPORTED_STRATEGIES
+from app.core.config import (
+    BUY_SIGNAL,
+    SELL_SIGNAL,
+    SMA200_VARIANTS,
+    SUPPORTED_STRATEGIES,
+)
 from app.trading.strat_trader import StratTrader
 from app.trading.strategies import STRATEGY_REGISTRY
+from app.trading.trader_driver import TraderDriver
 
 
 def _trader(**overrides):
@@ -43,11 +49,37 @@ def _add_day(trader, index, close, open_price=None, execute_strategy=True):
 def test_sma200_is_registered_and_adds_required_average():
     trader = _trader()
 
+    assert SMA200_VARIANTS == [
+        {"entry_band_pct": 0.05, "exit_band_pct": 0.05, "min_hold_days": 0}
+    ]
     assert "SMA200" in SUPPORTED_STRATEGIES
     assert STRATEGY_REGISTRY["SMA200"] is not None
     assert "200" in trader.moving_averages
     assert trader.buy_pct == 1.0
     assert trader.sell_pct == 1.0
+
+
+def test_trader_driver_creates_one_fixed_sma200_candidate():
+    grid = {
+        "overall_stats": ["MA-BOLL-BANDS", "SMA200"],
+        "tol_pcts": [0.1, 0.2],
+        "buy_pcts": [0.5, 1.0],
+        "sell_pcts": [0.5, 1.0],
+        "bollinger_tols": [2, 3],
+        "rsi_periods": [14],
+        "rsi_oversold_thresholds": [30],
+        "rsi_overbought_thresholds": [70],
+        "kdj_oversold_thresholds": [20],
+        "kdj_overbought_thresholds": [80],
+        "sma200_variants": [SMA200_VARIANTS[0]],
+    }
+
+    specs = list(TraderDriver._iter_trader_specs(**grid))
+    sma_specs = [spec for spec in specs if spec["stat"] == "SMA200"]
+
+    assert len(specs) == 17
+    assert len(sma_specs) == 1
+    assert TraderDriver.expected_trader_count(**grid) == 17
 
 
 def test_sma200_goes_all_in_above_average_and_exits_below_it():
@@ -66,6 +98,35 @@ def test_sma200_goes_all_in_above_average_and_exits_below_it():
 
     assert trader.cur_coin == 0
     assert trader.trade_history[-1]["action"] == SELL_SIGNAL
+
+
+def test_sma200_confirmation_band_filters_small_crosses():
+    trader = _trader(
+        sma200_entry_band_pct=0.03,
+        sma200_exit_band_pct=0.03,
+    )
+    for index in range(199):
+        _add_day(trader, index, 100, execute_strategy=False)
+
+    _add_day(trader, 199, 102)
+    assert trader.cur_coin == 0
+
+    _add_day(trader, 200, 104)
+    assert trader.cur_coin > 0
+
+
+def test_sma200_minimum_holding_period_delays_exit():
+    trader = _trader(sma200_min_hold_days=14)
+    for index in range(199):
+        _add_day(trader, index, 100, execute_strategy=False)
+
+    _add_day(trader, 199, 110)
+    for index in range(200, 213):
+        _add_day(trader, index, 90)
+        assert trader.cur_coin > 0
+
+    _add_day(trader, 213, 90)
+    assert trader.cur_coin == 0
 
 
 def test_sma200_signal_executes_at_next_open_when_enabled():


### PR DESCRIPTION
## Summary
- add SMA200 confirmation-band and holding-period parameters
- keep the selected 5% entry/exit variant as the runtime configuration
- add leakage-resistant BTC/ETH/SOL validation against baseline SMA200 and fixed MA-BOLL
- freeze SMA200 parameters correctly through walk-forward evaluation

## Validation
- 22 relevant tests passed
- BTC/ETH/SOL report included under artifacts/backtests