### PR TITLE
Register BTC SMA200 defensive strategy

### DIFF
--- a/app/api/server.py
+++ b/app/api/server.py
@@ -115,16 +115,24 @@ def run_trading_simulation():
 
         results = {}
 
-        for index, cur_name in enumerate(CURS):
+        crypto_assets = [
+            asset for asset in CURS if crypto_strategies_for_asset(asset)
+        ]
+        for index, cur_name in enumerate(crypto_assets):
+            asset_strategies = crypto_strategies_for_asset(cur_name)
             logger.info(f"[{index+1}] processing for currency={cur_name}...")
 
             try:
                 cur_rate = client.get_cur_rate(name=cur_name + "-USD")
-                data_stream = client.get_historic_data(name=cur_name + "-USD")
+                data_stream = client.get_historic_data(
+                    name=cur_name + "-USD",
+                    interval_hours=CRYPTO_SIGNAL_INTERVAL_HOURS,
+                    lookback_days=CRYPTO_SIGNAL_LOOKBACK_DAYS,
+                )
 
                 # cut-off, only want the last X days of data
-                data_stream = data_stream[-TIMESPAN:]
-                logger.info(f"only want the latest {TIMESPAN} days of data!")
+                data_stream = data_stream[-CRYPTO_SIGNAL_LOOKBACK_DAYS:]
+                logger.info(f"using the latest {CRYPTO_SIGNAL_LOOKBACK_DAYS} daily candles")
 
                 # initial cash amount
                 _, cash = client.portfolio_value
@@ -175,7 +183,7 @@ def run_trading_simulation():
                 t_driver = TraderDriver(
                     name=cur_name,
                     init_amount=int(sim_cash),
-                    overall_stats=STRATEGIES,
+                    overall_stats=asset_strategies,
                     cur_coin=sim_coin,
                     tol_pcts=TOL_PCTS,
                     ma_lengths=MA_LENGTHS,
@@ -196,6 +204,9 @@ def run_trading_simulation():
                     kdj_oversold_thresholds=KDJ_OVERSOLD_THRESHOLDS,
                     kdj_overbought_thresholds=KDJ_OVERBOUGHT_THRESHOLDS,
                     mode="normal",
+                    execute_on_next_open=CRYPTO_EXECUTE_ON_NEXT_OPEN,
+                    slippage_bps=CRYPTO_SLIPPAGE_BPS,
+                    enable_options=False,
                 )
 
                 t_driver.feed_data(data_stream)

--- a/app/backtesting/portfolio_strategy_validation.py
+++ b/app/backtesting/portfolio_strategy_validation.py
@@ -1,0 +1,552 @@
+"""Offline validation for cross-asset trend rotation strategies."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import asdict, dataclass
+from itertools import product
+from pathlib import Path
+from typing import Any, Sequence
+
+import numpy as np
+
+from app.backtesting.benchmark_validation import (
+    EXECUTION_FRICTION_RATE,
+    INITIAL_CAPITAL,
+)
+from app.backtesting.walk_forward import load_daily_data
+from app.core.config import BTC_SMA200_DEFENSIVE_STRATEGY, CURS
+
+
+@dataclass(frozen=True)
+class RotationParameters:
+    momentum_days: int
+    top_n: int
+    rebalance_days: int
+    inverse_volatility: bool
+    bollinger_pullback: bool
+
+
+@dataclass(frozen=True)
+class TrendParameters:
+    entry_band_pct: float
+    exit_band_pct: float
+    bollinger_entry_sigma: float | None
+
+
+def _rolling_mean(values: np.ndarray, window: int) -> np.ndarray:
+    result = np.full(len(values), np.nan)
+    if len(values) >= window:
+        result[window - 1 :] = np.convolve(
+            values, np.ones(window) / window, mode="valid"
+        )
+    return result
+
+
+def _rolling_std(values: np.ndarray, window: int) -> np.ndarray:
+    result = np.full(len(values), np.nan)
+    for index in range(window - 1, len(values)):
+        result[index] = float(np.std(values[index - window + 1 : index + 1]))
+    return result
+
+
+def load_aligned_assets(
+    symbols: Sequence[str],
+) -> tuple[list[str], dict[str, list[list[Any]]]]:
+    data_by_asset = {symbol: load_daily_data(symbol) for symbol in symbols}
+    if any(not data for data in data_by_asset.values()):
+        missing = [symbol for symbol, data in data_by_asset.items() if not data]
+        raise ValueError(f"Missing daily data for: {', '.join(missing)}")
+
+    reference_symbol = symbols[0]
+    reference_dates = [row[1] for row in data_by_asset[reference_symbol]]
+    for symbol, data in data_by_asset.items():
+        dates = [row[1] for row in data]
+        if dates != reference_dates:
+            raise ValueError(f"Daily dates are not aligned for {symbol}")
+    return reference_dates, data_by_asset
+
+
+def _feature_matrices(
+    symbols: Sequence[str], data_by_asset: dict[str, list[list[Any]]]
+) -> dict[str, np.ndarray]:
+    closes = np.column_stack(
+        [[float(row[0]) for row in data_by_asset[symbol]] for symbol in symbols]
+    )
+    opens = np.column_stack(
+        [[float(row[2]) for row in data_by_asset[symbol]] for symbol in symbols]
+    )
+    sma20 = np.column_stack(
+        [_rolling_mean(closes[:, index], 20) for index in range(len(symbols))]
+    )
+    std20 = np.column_stack(
+        [_rolling_std(closes[:, index], 20) for index in range(len(symbols))]
+    )
+    sma200 = np.column_stack(
+        [_rolling_mean(closes[:, index], 200) for index in range(len(symbols))]
+    )
+    returns = np.zeros_like(closes)
+    returns[1:] = closes[1:] / closes[:-1] - 1.0
+    vol20 = np.column_stack(
+        [_rolling_std(returns[:, index], 20) for index in range(len(symbols))]
+    )
+    return {
+        "closes": closes,
+        "opens": opens,
+        "sma20": sma20,
+        "std20": std20,
+        "sma200": sma200,
+        "vol20": vol20,
+    }
+
+
+def _hysteresis_states(
+    closes: np.ndarray,
+    sma200: np.ndarray,
+    entry_band_pct: float = 0.05,
+    exit_band_pct: float = 0.05,
+) -> np.ndarray:
+    states = np.zeros_like(closes, dtype=bool)
+    active = np.zeros(closes.shape[1], dtype=bool)
+    for index in range(len(closes)):
+        valid = ~np.isnan(sma200[index])
+        active[valid & (closes[index] > sma200[index] * (1.0 + entry_band_pct))] = True
+        active[valid & (closes[index] < sma200[index] * (1.0 - exit_band_pct))] = False
+        active[~valid] = False
+        states[index] = active
+    return states
+
+
+def build_equal_weight_targets(
+    features: dict[str, np.ndarray],
+    symbols: Sequence[str],
+    btc_gate: bool,
+) -> np.ndarray:
+    closes = features["closes"]
+    states = _hysteresis_states(closes, features["sma200"])
+    targets = np.zeros_like(closes)
+    btc_index = symbols.index("BTC")
+    for index in range(len(closes)):
+        eligible = states[index].copy()
+        if btc_gate and not states[index, btc_index]:
+            eligible[:] = False
+        count = int(np.sum(eligible))
+        if count:
+            targets[index, eligible] = 1.0 / count
+    return targets
+
+
+def build_rotation_targets(
+    features: dict[str, np.ndarray],
+    symbols: Sequence[str],
+    params: RotationParameters,
+) -> np.ndarray:
+    closes = features["closes"]
+    sma20 = features["sma20"]
+    std20 = features["std20"]
+    vol20 = features["vol20"]
+    states = _hysteresis_states(closes, features["sma200"])
+    targets = np.zeros_like(closes)
+    btc_index = symbols.index("BTC")
+    selected: list[int] = []
+    selected_weights: dict[int, float] = {}
+
+    for index in range(len(closes)):
+        if not states[index, btc_index]:
+            selected = []
+            selected_weights = {}
+            continue
+
+        selected = [asset for asset in selected if states[index, asset]]
+        selected_weights = {
+            asset: weight
+            for asset, weight in selected_weights.items()
+            if asset in selected
+        }
+        scheduled = index % params.rebalance_days == 0
+        if scheduled and index >= max(200, params.momentum_days):
+            scores = []
+            for asset in range(len(symbols)):
+                if not states[index, asset]:
+                    continue
+                past = closes[index - params.momentum_days, asset]
+                volatility = vol20[index, asset]
+                if past <= 0 or np.isnan(volatility) or volatility <= 0:
+                    continue
+                momentum = closes[index, asset] / past - 1.0
+                score = momentum / volatility
+                if params.bollinger_pullback and asset not in selected:
+                    upper_entry = sma20[index, asset] + 0.5 * std20[index, asset]
+                    if np.isnan(upper_entry) or closes[index, asset] > upper_entry:
+                        continue
+                scores.append((score, asset))
+            scores.sort(reverse=True)
+            selected = [asset for _, asset in scores[: params.top_n]]
+            selected_weights = {}
+
+        if not selected:
+            continue
+        if not selected_weights and params.inverse_volatility:
+            inverse_vol = np.asarray(
+                [
+                    1.0 / vol20[index, asset] if vol20[index, asset] > 0 else 0.0
+                    for asset in selected
+                ]
+            )
+            if np.sum(inverse_vol) <= 0:
+                continue
+            weights = inverse_vol / np.sum(inverse_vol)
+            selected_weights = {
+                asset: float(weight) for asset, weight in zip(selected, weights)
+            }
+        elif not selected_weights:
+            selected_weights = {asset: 1.0 / len(selected) for asset in selected}
+        else:
+            total_weight = sum(selected_weights.values())
+            selected_weights = {
+                asset: weight / total_weight
+                for asset, weight in selected_weights.items()
+            }
+        for asset, weight in selected_weights.items():
+            targets[index, asset] = weight
+    return targets
+
+
+def build_single_asset_trend_targets(
+    features: dict[str, np.ndarray],
+    symbols: Sequence[str],
+    symbol: str,
+    params: TrendParameters,
+) -> np.ndarray:
+    closes = features["closes"]
+    sma200 = features["sma200"]
+    sma20 = features["sma20"]
+    std20 = features["std20"]
+    asset = symbols.index(symbol)
+    targets = np.zeros_like(closes)
+    active = False
+
+    for index in range(len(closes)):
+        long_average = sma200[index, asset]
+        if np.isnan(long_average):
+            active = False
+            continue
+        close = closes[index, asset]
+        if active and close < long_average * (1.0 - params.exit_band_pct):
+            active = False
+        elif not active and close > long_average * (1.0 + params.entry_band_pct):
+            if params.bollinger_entry_sigma is None:
+                active = True
+            else:
+                entry_ceiling = (
+                    sma20[index, asset]
+                    + params.bollinger_entry_sigma * std20[index, asset]
+                )
+                if not np.isnan(entry_ceiling) and close <= entry_ceiling:
+                    active = True
+        if active:
+            targets[index, asset] = 1.0
+    return targets
+
+
+def simulate_portfolio(
+    features: dict[str, np.ndarray],
+    targets: np.ndarray,
+    test_start: int,
+    test_end: int,
+    slippage_bps: float = 10.0,
+) -> dict[str, Any]:
+    if test_start <= 0 or test_end <= test_start:
+        raise ValueError("Invalid test range")
+    opens = features["opens"]
+    closes = features["closes"]
+    asset_count = closes.shape[1]
+    cash = INITIAL_CAPITAL
+    quantities = np.zeros(asset_count)
+    trades = 0
+    turnover = 0.0
+    equity_curve = []
+    exposure_curve = []
+    executed_target = np.zeros(asset_count)
+    slip = slippage_bps / 10_000.0
+
+    for index in range(test_start, test_end):
+        desired = np.asarray(targets[index - 1], dtype=float)
+        if not np.allclose(desired, executed_target, atol=1e-10):
+            open_prices = opens[index]
+            starting_equity = cash + float(np.dot(quantities, open_prices))
+            desired_values = desired * starting_equity
+            current_values = quantities * open_prices
+
+            for asset in range(asset_count):
+                excess_value = current_values[asset] - desired_values[asset]
+                if excess_value <= 1e-8:
+                    continue
+                sell_quantity = min(
+                    quantities[asset], excess_value / open_prices[asset]
+                )
+                execution_price = open_prices[asset] * (1.0 - slip)
+                quantities[asset] -= sell_quantity
+                cash += (
+                    sell_quantity * execution_price * (1.0 - EXECUTION_FRICTION_RATE)
+                )
+                turnover += excess_value / starting_equity
+                trades += 1
+
+            current_values = quantities * open_prices
+            deficits = np.maximum(0.0, desired_values - current_values)
+            total_deficit = float(np.sum(deficits))
+            scale = min(1.0, cash / total_deficit) if total_deficit > 0 else 0.0
+            for asset in range(asset_count):
+                spend = deficits[asset] * scale
+                if spend <= 1e-8:
+                    continue
+                execution_price = open_prices[asset] * (1.0 + slip)
+                quantities[asset] += (
+                    spend * (1.0 - EXECUTION_FRICTION_RATE) / execution_price
+                )
+                cash -= spend
+                turnover += spend / starting_equity
+                trades += 1
+            executed_target = desired.copy()
+
+        equity = cash + float(np.dot(quantities, closes[index]))
+        equity_curve.append(equity)
+        invested = float(np.dot(quantities, closes[index]))
+        exposure_curve.append(invested / equity if equity > 0 else 0.0)
+
+    curve = np.asarray(equity_curve)
+    curve_with_initial_capital = np.concatenate(([INITIAL_CAPITAL], curve))
+    peaks = np.maximum.accumulate(curve_with_initial_capital)
+    drawdowns = (peaks - curve_with_initial_capital) / peaks
+    return {
+        "return": (curve[-1] / INITIAL_CAPITAL - 1.0) * 100.0,
+        "max_drawdown": float(np.max(drawdowns)) * 100.0,
+        "transactions": trades,
+        "turnover": turnover,
+        "mean_exposure": float(np.mean(exposure_curve)),
+        "final_value": float(curve[-1]),
+    }
+
+
+def _score(metrics: dict[str, Any]) -> float:
+    return float(metrics["return"]) - 0.25 * float(metrics["max_drawdown"])
+
+
+def run_validation(
+    symbols: Sequence[str],
+    train_days: int = 365,
+    validation_days: int = 90,
+    purge_days: int = 7,
+    slippage_bps: float = 10.0,
+) -> dict[str, Any]:
+    dates, data_by_asset = load_aligned_assets(symbols)
+    features = _feature_matrices(symbols, data_by_asset)
+    validation_end = train_days + validation_days
+    test_start = validation_end + purge_days
+    if len(dates) <= test_start:
+        raise ValueError("Not enough rows for the requested split")
+
+    cash_targets = np.zeros_like(features["closes"])
+    buy_hold_targets = np.full_like(features["closes"], 1.0 / len(symbols), dtype=float)
+    equal_targets = build_equal_weight_targets(features, symbols, btc_gate=False)
+    gated_equal_targets = build_equal_weight_targets(features, symbols, btc_gate=True)
+
+    candidates = [
+        RotationParameters(momentum, top_n, rebalance, inverse_vol, bollinger)
+        for momentum, top_n, rebalance, inverse_vol, bollinger in product(
+            (60, 90, 120),
+            (2, 3),
+            (14, 30),
+            (False, True),
+            (False, True),
+        )
+    ]
+    candidate_results = []
+    for candidate in candidates:
+        targets = build_rotation_targets(features, symbols, candidate)
+        train_metrics = simulate_portfolio(
+            features, targets, 200, train_days, slippage_bps
+        )
+        validation_metrics = simulate_portfolio(
+            features, targets, train_days, validation_end, slippage_bps
+        )
+        candidate_results.append(
+            {
+                "parameters": candidate,
+                "train": train_metrics,
+                "validation": validation_metrics,
+            }
+        )
+
+    shortlist = sorted(
+        candidate_results, key=lambda item: _score(item["train"]), reverse=True
+    )[:12]
+    selected_result = max(shortlist, key=lambda item: _score(item["validation"]))
+    selected = selected_result["parameters"]
+    selected_targets = build_rotation_targets(features, symbols, selected)
+
+    trend_candidates = [
+        TrendParameters(entry_band, exit_band, bollinger_sigma)
+        for entry_band, exit_band, bollinger_sigma in product(
+            (0.0, 0.03, 0.05),
+            (0.0, 0.03, 0.05),
+            (None, 0.5, 1.0),
+        )
+    ]
+    trend_candidate_results = []
+    for candidate in trend_candidates:
+        targets = build_single_asset_trend_targets(features, symbols, "BTC", candidate)
+        trend_candidate_results.append(
+            {
+                "parameters": candidate,
+                "train": simulate_portfolio(
+                    features, targets, 200, train_days, slippage_bps
+                ),
+                "validation": simulate_portfolio(
+                    features, targets, train_days, validation_end, slippage_bps
+                ),
+            }
+        )
+    trend_shortlist = sorted(
+        trend_candidate_results,
+        key=lambda item: _score(item["train"]),
+        reverse=True,
+    )[:9]
+    selected_trend_result = max(
+        trend_shortlist, key=lambda item: _score(item["validation"])
+    )
+    selected_trend = selected_trend_result["parameters"]
+    selected_trend_targets = build_single_asset_trend_targets(
+        features, symbols, "BTC", selected_trend
+    )
+
+    fixed_rotation = RotationParameters(90, 2, 30, False, False)
+    fixed_bollinger = RotationParameters(90, 2, 30, False, True)
+    fixed_btc_defensive = TrendParameters(0.05, 0.05, None)
+    btc_defensive_targets = build_single_asset_trend_targets(
+        features, symbols, "BTC", fixed_btc_defensive
+    )
+    btc_buy_hold_targets = np.zeros_like(features["closes"])
+    btc_buy_hold_targets[:, symbols.index("BTC")] = 1.0
+    strategy_targets = {
+        "cash": cash_targets,
+        "equal_buy_hold": buy_hold_targets,
+        "sma5_equal": equal_targets,
+        "btc_gate_sma5_equal": gated_equal_targets,
+        "btc_gate_top2_momentum": build_rotation_targets(
+            features, symbols, fixed_rotation
+        ),
+        "btc_gate_top2_momentum_bollinger": build_rotation_targets(
+            features, symbols, fixed_bollinger
+        ),
+        "selected_rotation": selected_targets,
+        "selected_btc_trend": selected_trend_targets,
+        "btc_sma5_defensive": btc_defensive_targets,
+        "btc_buy_hold": btc_buy_hold_targets,
+    }
+    test_results = {
+        name: simulate_portfolio(
+            features, targets, test_start, len(dates), slippage_bps
+        )
+        for name, targets in strategy_targets.items()
+    }
+
+    long_horizon_results = {
+        "btc_sma5_defensive": simulate_portfolio(
+            features, btc_defensive_targets, 200, len(dates), slippage_bps
+        ),
+        "btc_buy_hold": simulate_portfolio(
+            features, btc_buy_hold_targets, 200, len(dates), slippage_bps
+        ),
+    }
+
+    return {
+        "configuration": {
+            "symbols": list(symbols),
+            "data_start": dates[0],
+            "data_end": dates[-1],
+            "data_rows": len(dates),
+            "train": {"start": dates[0], "end": dates[train_days - 1]},
+            "validation": {
+                "start": dates[train_days],
+                "end": dates[validation_end - 1],
+            },
+            "purge_days": purge_days,
+            "test": {"start": dates[test_start], "end": dates[-1]},
+            "execution_friction_rate": EXECUTION_FRICTION_RATE,
+            "slippage_bps": slippage_bps,
+            "signal_time": "daily_close",
+            "execution_time": "next_daily_open",
+        },
+        "selected_parameters": asdict(selected),
+        "selected_train": selected_result["train"],
+        "selected_validation": selected_result["validation"],
+        "selected_btc_trend_parameters": asdict(selected_trend),
+        "selected_btc_trend_train": selected_trend_result["train"],
+        "selected_btc_trend_validation": selected_trend_result["validation"],
+        "recommended_strategy": {
+            "name": BTC_SMA200_DEFENSIVE_STRATEGY,
+            "parameters": asdict(fixed_btc_defensive),
+            "rationale": (
+                "Fixed low-turnover BTC trend filter; rotation and Bollinger-entry "
+                "ablations failed under the same cost model."
+            ),
+        },
+        "long_horizon_results": long_horizon_results,
+        "btc_trend_candidate_results": [
+            {
+                "parameters": asdict(item["parameters"]),
+                "train": item["train"],
+                "validation": item["validation"],
+            }
+            for item in trend_candidate_results
+        ],
+        "candidate_results": [
+            {
+                "parameters": asdict(item["parameters"]),
+                "train": item["train"],
+                "validation": item["validation"],
+            }
+            for item in candidate_results
+        ],
+        "test_results": test_results,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--symbols", nargs="+", default=CURS)
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+
+    report = run_validation(args.symbols)
+    output = args.output or Path(
+        "artifacts/backtests/portfolio_strategy_validation.json"
+    )
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(report, indent=2), encoding="utf-8")
+    print("Selected rotation parameters:", report["selected_parameters"])
+    print(
+        "Selected BTC trend parameters:",
+        report["selected_btc_trend_parameters"],
+    )
+    for name, metrics in report["test_results"].items():
+        print(
+            f"{name}: return={metrics['return']:.2f}%, "
+            f"drawdown={metrics['max_drawdown']:.2f}%, "
+            f"trades={metrics['transactions']}"
+        )
+    print("Long-horizon comparison:")
+    for name, metrics in report["long_horizon_results"].items():
+        print(
+            f"{name}: return={metrics['return']:.2f}%, "
+            f"drawdown={metrics['max_drawdown']:.2f}%, "
+            f"trades={metrics['transactions']}"
+        )
+    print(f"Saved report: {output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/app/backtesting/walk_forward.py
+++ b/app/backtesting/walk_forward.py
@@ -13,6 +13,7 @@ from typing import Any, Iterable, Sequence
 from sqlalchemy import select
 
 from app.core.config import (
+    BTC_SMA200_DEFENSIVE_STRATEGY,
     BOLLINGER_MAS,
     BOLLINGER_TOLS,
     BUY_PCTS,
@@ -29,6 +30,7 @@ from app.core.config import (
     SELL_PCTS,
     SELL_STAS,
     TOL_PCTS,
+    crypto_strategies_for_asset,
 )
 from app.db.database import HistoricalData, SessionLocal
 from app.trading.trader_driver import TraderDriver
@@ -233,7 +235,8 @@ def _driver_kwargs(
                     "min_hold_days": candidate.sma200_min_hold_days,
                 }
             ]
-            if candidate and candidate.strategy == "SMA200"
+            if candidate
+            and candidate.strategy in {"SMA200", BTC_SMA200_DEFENSIVE_STRATEGY}
             else None
         ),
     }
@@ -280,7 +283,7 @@ def run_symbol_walk_forward(
     test_days: int = 30,
     purge_days: int = 7,
     top_k: int = 10,
-    warmup_days: int = 35,
+    warmup_days: int = 200,
     slippage_bps: float = 10.0,
     max_folds: int | None = None,
 ) -> dict[str, Any]:
@@ -311,9 +314,7 @@ def run_symbol_walk_forward(
             ) : fold.validation_start
         ]
         test_warmup = data[
-            max(
-                fold.validation_end - warmup_days, fold.validation_start
-            ) : fold.test_start
+            max(fold.test_start - warmup_days, fold.train_start) : fold.test_start
         ]
 
         training_candidates = _train_candidates(symbol, train_data, top_k, slippage_bps)
@@ -399,13 +400,17 @@ def run_symbol_walk_forward(
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Strict daily walk-forward backtest")
-    parser.add_argument("--symbols", nargs="+", default=CURS)
+    parser.add_argument(
+        "--symbols",
+        nargs="+",
+        default=[symbol for symbol in CURS if crypto_strategies_for_asset(symbol)],
+    )
     parser.add_argument("--train-days", type=int, default=365)
     parser.add_argument("--validation-days", type=int, default=90)
     parser.add_argument("--test-days", type=int, default=30)
     parser.add_argument("--purge-days", type=int, default=7)
     parser.add_argument("--top-k", type=int, default=10)
-    parser.add_argument("--warmup-days", type=int, default=35)
+    parser.add_argument("--warmup-days", type=int, default=200)
     parser.add_argument("--slippage-bps", type=float, default=10.0)
     parser.add_argument("--max-folds", type=int)
     parser.add_argument("--output", type=Path)

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -17,7 +17,10 @@ DEBUG = False
 #
 # NOTE: We keep `STRATEGIES` as a backward-compatible alias to `CRYPTO_STRATEGIES` because many scripts/tests
 # pass it into `TraderDriver(overall_stats=...)`.
+BTC_SMA200_DEFENSIVE_STRATEGY = "BTC-SMA200-DEFENSIVE"
+
 SUPPORTED_STRATEGIES = [
+    BTC_SMA200_DEFENSIVE_STRATEGY,
     "SMA200",
     "MA-SELVES",
     "MA-SELVES-MACRO",
@@ -50,9 +53,47 @@ SUPPORTED_STRATEGIES = [
 
 # Enabled strategies (crypto)
 CRYPTO_STRATEGIES = [
-    "MA-BOLL-BANDS",
-    "SMA200",
+    BTC_SMA200_DEFENSIVE_STRATEGY,
 ]
+
+BTC_SMA200_DEFENSIVE_ASSETS = frozenset({"BTC"})
+BTC_SMA200_DEFENSIVE_PARAMETERS = {
+    "entry_band_pct": 0.05,
+    "exit_band_pct": 0.05,
+    "min_hold_days": 0,
+}
+CRYPTO_STRATEGY_ASSET_ALLOWLIST = {
+    BTC_SMA200_DEFENSIVE_STRATEGY: BTC_SMA200_DEFENSIVE_ASSETS,
+}
+CRYPTO_EXECUTE_ON_NEXT_OPEN = True
+CRYPTO_SLIPPAGE_BPS = 10.0
+CRYPTO_SIGNAL_INTERVAL_HOURS = 24
+CRYPTO_SIGNAL_LOOKBACK_DAYS = 365
+
+
+def normalize_crypto_asset(asset: str) -> str:
+    """Normalize exchange pairs and file-derived fixture names to a base asset."""
+    normalized = str(asset).replace("\\", "/").rsplit("/", 1)[-1].upper()
+    return normalized.replace("-USD", "").replace("USDT", "")
+
+
+def crypto_strategies_for_asset(asset: str):
+    """Return enabled crypto strategies that are allowed to trade the asset."""
+    normalized_asset = normalize_crypto_asset(asset)
+    return [
+        strategy
+        for strategy in CRYPTO_STRATEGIES
+        if normalized_asset in CRYPTO_STRATEGY_ASSET_ALLOWLIST.get(
+            strategy, {normalized_asset}
+        )
+    ]
+
+
+def is_crypto_strategy_allowed_for_asset(strategy: str, asset: str) -> bool:
+    """Enforce any asset allowlist attached to a registered crypto strategy."""
+    normalized_asset = normalize_crypto_asset(asset)
+    allowed_assets = CRYPTO_STRATEGY_ASSET_ALLOWLIST.get(strategy)
+    return allowed_assets is None or normalized_asset in allowed_assets
 
 # Enabled strategies (stocks) - daily candles only; keep separate from crypto
 STOCK_STRATEGIES = [
@@ -80,7 +121,7 @@ BOLLINGER_MAS = [6, 12]
 BOLLINGER_TOLS = [2, 3, 4, 5]
 
 SMA200_VARIANTS = [
-    {"entry_band_pct": 0.05, "exit_band_pct": 0.05, "min_hold_days": 0},
+    BTC_SMA200_DEFENSIVE_PARAMETERS.copy(),
 ]
 
 # --- MA-BOLL-BANDS zoom-in configuration ---

--- a/app/core/main.py
+++ b/app/core/main.py
@@ -592,7 +592,14 @@ def main_defi():
         logger.warning("DEFI event client email not sent: missing credentials in secret.ini")
 
 
-def fetch_historical_data_with_fallback(asset: str, binance_client: BinanceClient, coinbase_client: CBProClient, exchange_configs: list):
+def fetch_historical_data_with_fallback(
+    asset: str,
+    binance_client: BinanceClient,
+    coinbase_client: CBProClient,
+    exchange_configs: list,
+    interval_hours: int = DATA_INTERVAL_HOURS,
+    lookback_days: int = TIMESPAN,
+):
     """
     Fetch historical data for an asset, trying Binance first, then falling back to Coinbase.
     
@@ -630,7 +637,11 @@ def fetch_historical_data_with_fallback(asset: str, binance_client: BinanceClien
         try:
             binance_symbol = binance_config["symbol_format"](asset)
             logger.info(f"Attempting to fetch {asset} data from Binance using symbol: {binance_symbol}")
-            data_stream = binance_client.get_historic_data(binance_symbol)
+            data_stream = binance_client.get_historic_data(
+                binance_symbol,
+                interval_hours=interval_hours,
+                lookback_days=lookback_days,
+            )
             
             # Validate and format the data
             formatted_data = validate_and_format_data(data_stream)
@@ -648,7 +659,11 @@ def fetch_historical_data_with_fallback(asset: str, binance_client: BinanceClien
         try:
             coinbase_symbol = coinbase_config["symbol_format"](asset)
             logger.info(f"Attempting to fetch {asset} data from Coinbase using symbol: {coinbase_symbol}")
-            data_stream = coinbase_client.get_historic_data(coinbase_symbol)
+            data_stream = coinbase_client.get_historic_data(
+                coinbase_symbol,
+                interval_hours=interval_hours,
+                lookback_days=lookback_days,
+            )
             
             # Validate and format the data
             formatted_data = validate_and_format_data(data_stream)
@@ -822,9 +837,9 @@ def _run_stock_simulation(all_actions: list, best_summaries: Optional[list] = No
             trader_driver.feed_data(data_stream)
             best_info = trader_driver.best_trader_info
             best_t = trader_driver.traders[best_info["trader_index"]]
-            # For crypto (6h candles), avoid missing a recent actionable signal by looking back 24 hours.
+            # Daily-close signals execute on the next daily open; inspect the latest two days.
             try:
-                signal = best_t.get_trade_signal(lag_intervals=0, lookback_hours=24)
+                signal = best_t.get_trade_signal(lag_intervals=0, lookback_hours=48)
             except Exception:
                 signal = best_t.trade_signal
             if best_summaries is not None:
@@ -1165,8 +1180,14 @@ def main(asset: str = "all"):
             v_c=exchange["crypto_value"], v_s=exchange["stablecoin_value"], before=True
         )
 
-    asset_list = CURS[:1] if DEBUG else CURS # only test 1 asset for debugging purposes
+    configured_assets = CURS[:1] if DEBUG else CURS
+    asset_list = [
+        candidate
+        for candidate in configured_assets
+        if crypto_strategies_for_asset(candidate)
+    ]
     for asset in asset_list:
+        asset_strategies = crypto_strategies_for_asset(asset)
         # Only simulate each asset once, regardless of exchange
         if asset in simulated_assets:
             logger.info(f"Skipping duplicate simulation for asset: {asset}")
@@ -1179,7 +1200,12 @@ def main(asset: str = "all"):
         
         # Use fallback approach: try Binance first, then Coinbase
         data_stream, source_exchange = fetch_historical_data_with_fallback(
-            asset, binance_client, coinbase_client, EXCHANGE_CONFIGS
+            asset,
+            binance_client,
+            coinbase_client,
+            EXCHANGE_CONFIGS,
+            interval_hours=CRYPTO_SIGNAL_INTERVAL_HOURS,
+            lookback_days=CRYPTO_SIGNAL_LOOKBACK_DAYS,
         )
         
         if data_stream is None:
@@ -1189,7 +1215,7 @@ def main(asset: str = "all"):
         logger.info(f"Using data from {source_exchange.value} for {asset}")
 
         intraday_stream = None
-        if MA_BOLL_ZOOM_IN:
+        if "MA-BOLL-BANDS" in asset_strategies and MA_BOLL_ZOOM_IN:
             try:
                 intraday_stream = fetch_intraday_data_with_fallback(
                     asset=asset,
@@ -1256,22 +1282,22 @@ def main(asset: str = "all"):
                 logger.error(f"No historical data available for {asset}")
                 continue
             
-            if len(data_stream) < 2:
-                logger.error(f"Insufficient historical data for {asset}: only {len(data_stream)} data points available")
+            if len(data_stream) < 200:
+                logger.error(f"Insufficient daily history for {asset}: {len(data_stream)} rows; SMA200 needs at least 200")
                 continue
             
-            # Convert window size from days to data points based on DATA_INTERVAL_HOURS
-            # Data points per day = 24 hours / DATA_INTERVAL_HOURS
-            data_points_per_day = 24 / DATA_INTERVAL_HOURS
-            window_size_data_points = int(MOVING_WINDOW_DAYS * data_points_per_day)
-            step_size_data_points = int(MOVING_WINDOW_STEP * data_points_per_day)
+            # The strategy was validated on daily candles. Use all fetched rows as one
+            # evaluation window so SMA200 receives a complete warmup period.
+            data_points_per_day = 24 / CRYPTO_SIGNAL_INTERVAL_HOURS
+            window_size_data_points = len(data_stream)
+            step_size_data_points = len(data_stream)
             
             logger.info(
                 f"Starting moving window simulation for {asset} using {source_exchange.value} data "
-                f"with {len(data_stream)} data points (window size: {MOVING_WINDOW_DAYS} days = {window_size_data_points} data points, step: {MOVING_WINDOW_STEP} days = {step_size_data_points} data points)"
+                f"with {len(data_stream)} daily data points (single full-history evaluation window)"
             )
             logger.info(
-                f"Data interval configuration: {DATA_INTERVAL_HOURS}h intervals, "
+                f"Data interval configuration: {CRYPTO_SIGNAL_INTERVAL_HOURS}h intervals, "
                 f"~{data_points_per_day:.2f} data points per day, "
                 f"total data span covers ~{len(data_stream) / data_points_per_day:.1f} days"
             )
@@ -1286,7 +1312,7 @@ def main(asset: str = "all"):
                 init_amount=source_exchange_config["stablecoin_value"],
                 cur_coin=sim_coin_amount,
                 # only test 1 strategy for debugging purposes
-                overall_stats=CRYPTO_STRATEGIES if DEBUG is not True else CRYPTO_STRATEGIES[:5],
+                overall_stats=asset_strategies,
                 tol_pcts=TOL_PCTS,
                 ma_lengths=MA_LENGTHS,
                 ema_lengths=EMA_LENGTHS,
@@ -1302,6 +1328,9 @@ def main(asset: str = "all"):
                 kdj_oversold_thresholds=KDJ_OVERSOLD_THRESHOLDS,
                 kdj_overbought_thresholds=KDJ_OVERBOUGHT_THRESHOLDS,
                 mode="normal",
+                execute_on_next_open=CRYPTO_EXECUTE_ON_NEXT_OPEN,
+                slippage_bps=CRYPTO_SLIPPAGE_BPS,
+                enable_options=False,
             )
             
             # Get aggregated metrics for best strategy
@@ -1316,7 +1345,7 @@ def main(asset: str = "all"):
                 init_amount=source_exchange_config["stablecoin_value"],
                 cur_coin=sim_coin_amount,
                 # only test 1 strategy for debugging purposes
-                overall_stats=CRYPTO_STRATEGIES if DEBUG is not True else CRYPTO_STRATEGIES[:5],
+                overall_stats=asset_strategies,
                 tol_pcts=TOL_PCTS,
                 ma_lengths=MA_LENGTHS,
                 ema_lengths=EMA_LENGTHS,
@@ -1335,6 +1364,9 @@ def main(asset: str = "all"):
                 zoom_in_min_move_pct=MA_BOLL_ZOOM_IN_MIN_MOVE_PCT,
                 ma_boll_simplify=MA_BOLL_SIMPLIFY,
                 mode="normal",
+                execute_on_next_open=CRYPTO_EXECUTE_ON_NEXT_OPEN,
+                slippage_bps=CRYPTO_SLIPPAGE_BPS,
+                enable_options=False,
             )
             trader_driver.feed_data(
                 data_stream,
@@ -1343,9 +1375,9 @@ def main(asset: str = "all"):
             )
             best_info = trader_driver.best_trader_info
             best_t = trader_driver.traders[best_info["trader_index"]]
-            # For crypto (6h candles), avoid missing a recent actionable signal by looking back 24 hours.
+            # Daily-close signals execute on the next daily open; inspect the latest two days.
             try:
-                signal = best_t.get_trade_signal(lag_intervals=0, lookback_hours=24)
+                signal = best_t.get_trade_signal(lag_intervals=0, lookback_hours=48)
             except Exception:
                 signal = best_t.trade_signal
             th = getattr(best_t, "trade_history", []) or []

--- a/app/trading/cbpro_client.py
+++ b/app/trading/cbpro_client.py
@@ -36,7 +36,11 @@ class CBProClient:
 
     @timer
     def get_historic_data(
-        self, name: str, use_cache: bool = True, interval_hours: Optional[int] = None
+        self,
+        name: str,
+        use_cache: bool = True,
+        interval_hours: Optional[int] = None,
+        lookback_days: Optional[int] = None,
     ):
         """Get historic rates using Advanced Trade API with database caching.
 
@@ -44,6 +48,7 @@ class CBProClient:
             name (str): The product_id or currency pair (e.g., 'BTC-USD').
             use_cache (bool): Whether to use cached data if available and fresh.
             interval_hours (Optional[int]): Interval in hours. Defaults to DATA_INTERVAL_HOURS.
+            lookback_days (Optional[int]): UTC calendar days to request. Defaults to TIMESPAN.
 
         Returns:
             list: Each element is [closing_price (float), datetime (str, 'YYYY-MM-DD HH:MM:SS'), open_price (float), low (float), high (float), volume (float)].
@@ -56,10 +61,13 @@ class CBProClient:
         # cached rows can silently mismatch the requested granularity. Use a granularity-specific cache key.
         granularity_map = {1: "ONE_HOUR", 6: "SIX_HOURS", 12: "TWELVE_HOURS", 24: "ONE_DAY"}
         interval_base = DATA_INTERVAL_HOURS if interval_hours is None else int(interval_hours)
+        requested_days = TIMESPAN if lookback_days is None else int(lookback_days)
+        if requested_days <= 0:
+            raise ValueError(f"lookback_days must be positive, got {requested_days}")
         granularity = granularity_map.get(interval_base, "SIX_HOURS")
         cache_key = f"{name}__{granularity}"
         if use_cache:
-            cached_data = db_manager.get_historical_data(cache_key, TIMESPAN)
+            cached_data = db_manager.get_historical_data(cache_key, requested_days)
             if cached_data and db_manager.is_data_fresh(cache_key, max_age_hours=72):
                 self.logger.info(
                     f"Using cached data for {name} ({len(cached_data)} records, granularity: {granularity})"
@@ -75,7 +83,7 @@ class CBProClient:
         # Fetch fresh data from API
         try:
             end = datetime.now(timezone.utc)
-            start = end - timedelta(days=TIMESPAN)
+            start = end - timedelta(days=requested_days)
             self.logger.info(f"Fetching candles for {name} from {start.strftime('%Y-%m-%d %H:%M:%S')} to {end.strftime('%Y-%m-%d %H:%M:%S')}")
             
             res = self.rest_client.get_candles(

--- a/app/trading/strat_trader.py
+++ b/app/trading/strat_trader.py
@@ -10,6 +10,11 @@ import numpy as np
 
 # customized packages
 from app.core.config import (
+    BTC_SMA200_DEFENSIVE_PARAMETERS,
+    BTC_SMA200_DEFENSIVE_STRATEGY,
+    CRYPTO_EXECUTE_ON_NEXT_OPEN,
+    CRYPTO_SLIPPAGE_BPS,
+    is_crypto_strategy_allowed_for_asset,
     BUY_SIGNAL,
     DEA_NUM_OF_DAYS,
     DEPOSIT_CST,
@@ -93,8 +98,21 @@ class StratTrader:
         # Enabled strategies differ between crypto vs stocks (see config.CRYPTO_STRATEGIES/STOCK_STRATEGIES).
         if stat not in SUPPORTED_STRATEGIES:
             raise ValueError("Unknown high-level trading strategy!")
+        if stat == BTC_SMA200_DEFENSIVE_STRATEGY:
+            if not is_crypto_strategy_allowed_for_asset(
+                BTC_SMA200_DEFENSIVE_STRATEGY, name
+            ):
+                raise ValueError(
+                    f"{BTC_SMA200_DEFENSIVE_STRATEGY} is restricted to BTC; "
+                    f"received {name}"
+                )
+            sma200_entry_band_pct = BTC_SMA200_DEFENSIVE_PARAMETERS["entry_band_pct"]
+            sma200_exit_band_pct = BTC_SMA200_DEFENSIVE_PARAMETERS["exit_band_pct"]
+            sma200_min_hold_days = BTC_SMA200_DEFENSIVE_PARAMETERS["min_hold_days"]
+            execute_on_next_open = CRYPTO_EXECUTE_ON_NEXT_OPEN
+            slippage_bps = CRYPTO_SLIPPAGE_BPS
         ma_lengths = list(ma_lengths)
-        if stat == "SMA200" and 200 not in ma_lengths:
+        if stat in {"SMA200", BTC_SMA200_DEFENSIVE_STRATEGY} and 200 not in ma_lengths:
             ma_lengths.append(200)
         if not all([x in ma_lengths for x in bollinger_mas]):
             raise ValueError(
@@ -133,7 +151,7 @@ class StratTrader:
         # 3. Trading Strategy
         # buy percentage (how much you want to invest) of your cash
         # sell percentage (how much you want to sell off) from your coin
-        if stat == "SMA200":
+        if stat in {"SMA200", BTC_SMA200_DEFENSIVE_STRATEGY}:
             self.buy_pct, self.sell_pct = 1.0, 1.0
         else:
             self.buy_pct, self.sell_pct = buy_pct, sell_pct
@@ -160,12 +178,17 @@ class StratTrader:
         self.sma200_entry_band_pct = float(sma200_entry_band_pct)
         self.sma200_exit_band_pct = float(sma200_exit_band_pct)
         self.sma200_min_hold_days = int(sma200_min_hold_days)
-        if min(
-            self.sma200_entry_band_pct,
-            self.sma200_exit_band_pct,
-            self.sma200_min_hold_days,
-        ) < 0:
-            raise ValueError("SMA200 bands and minimum holding period cannot be negative")
+        if (
+            min(
+                self.sma200_entry_band_pct,
+                self.sma200_exit_band_pct,
+                self.sma200_min_hold_days,
+            )
+            < 0
+        ):
+            raise ValueError(
+                "SMA200 bands and minimum holding period cannot be negative"
+            )
         self.execute_on_next_open = execute_on_next_open
         self.slippage_bps = float(slippage_bps)
         if self.slippage_bps < 0:
@@ -232,7 +255,7 @@ class StratTrader:
         if self.high_strategy in STRATEGY_REGISTRY:
             strategy_func = STRATEGY_REGISTRY[self.high_strategy]
 
-            if self.high_strategy == "SMA200":
+            if self.high_strategy in {"SMA200", BTC_SMA200_DEFENSIVE_STRATEGY}:
                 strategy_func(
                     trader=self,
                     new_p=new_p,
@@ -1226,7 +1249,7 @@ class StratTrader:
             "tol_pct": self.tol_pct,
             "bollinger_sigma": self.bollinger_sigma,
         }
-        if self.high_strategy == "SMA200":
+        if self.high_strategy in {"SMA200", BTC_SMA200_DEFENSIVE_STRATEGY}:
             basic.update(
                 {
                     "sma200_entry_band_pct": self.sma200_entry_band_pct,

--- a/app/trading/strategies.py
+++ b/app/trading/strategies.py
@@ -7,7 +7,15 @@ from typing import Dict, List, Optional, Tuple
 
 import numpy as np
 
-from app.core.config import BUY_SIGNAL, NO_ACTION_SIGNAL, SELL_SIGNAL, STRATEGIES, SUPPORTED_STRATEGIES
+from app.core.config import (
+    BTC_SMA200_DEFENSIVE_STRATEGY,
+    BUY_SIGNAL,
+    NO_ACTION_SIGNAL,
+    SELL_SIGNAL,
+    STRATEGIES,
+    SUPPORTED_STRATEGIES,
+    is_crypto_strategy_allowed_for_asset,
+)
 from app.core.logger import get_logger
 
 # IMPORTANT:
@@ -361,9 +369,9 @@ def strategy_sma200(
     entry_band_pct: float = 0.0,
     exit_band_pct: float = 0.0,
     min_hold_days: int = 0,
+    strat_name: str = "SMA200",
 ) -> Tuple[bool, bool]:
     """Hold above SMA200 with optional hysteresis bands and a minimum holding period."""
-    strat_name = "SMA200"
     assert strat_name in STRATEGIES, "Unknown trading strategy name!"
 
     sma_values = getattr(trader, "moving_averages", {}).get("200", [])
@@ -409,6 +417,33 @@ def strategy_sma200(
         trader.strat_dct[strat_name].append((today, NO_ACTION_SIGNAL))
 
     return r_buy, r_sell
+
+
+def strategy_btc_sma200_defensive(
+    trader,
+    new_p: float,
+    today: datetime.datetime,
+    entry_band_pct: float = 0.05,
+    exit_band_pct: float = 0.05,
+    min_hold_days: int = 0,
+) -> Tuple[bool, bool]:
+    """Trade the fixed defensive SMA200 rule and reject every non-BTC asset."""
+    if not is_crypto_strategy_allowed_for_asset(
+        BTC_SMA200_DEFENSIVE_STRATEGY, trader.crypto_name
+    ):
+        raise ValueError(
+            f"{BTC_SMA200_DEFENSIVE_STRATEGY} is restricted to BTC; "
+            f"received {trader.crypto_name}"
+        )
+    return strategy_sma200(
+        trader=trader,
+        new_p=new_p,
+        today=today,
+        entry_band_pct=entry_band_pct,
+        exit_band_pct=exit_band_pct,
+        min_hold_days=min_hold_days,
+        strat_name=BTC_SMA200_DEFENSIVE_STRATEGY,
+    )
 
 
 def strategy_double_moving_averages(
@@ -4308,6 +4343,7 @@ def strategy_adaptive_ma_selves_macro_enhanced(
 # ---- Strategy registry for easy lookup ---- #
 STRATEGY_REGISTRY = {
     "ECONOMIC-INDICATORS": EconomicIndicatorsStrategy,
+    BTC_SMA200_DEFENSIVE_STRATEGY: strategy_btc_sma200_defensive,
     "SMA200": strategy_sma200,
     "MA-SELVES": strategy_moving_average_w_tolerance,
     "MA-SELVES-MACRO": strategy_ma_selves_macro_enhanced,

--- a/app/trading/trader_driver.py
+++ b/app/trading/trader_driver.py
@@ -10,6 +10,8 @@ import numpy as np
 
 # customized packages
 from app.core.config import (
+    BTC_SMA200_DEFENSIVE_PARAMETERS,
+    BTC_SMA200_DEFENSIVE_STRATEGY,
     KDJ_OVERBOUGHT_THRESHOLDS,
     KDJ_OVERSOLD_THRESHOLDS,
     ROUND_PRECISION,
@@ -17,6 +19,7 @@ from app.core.config import (
     RSI_OVERSOLD_THRESHOLDS,
     RSI_PERIODS,
     SMA200_VARIANTS,
+    is_crypto_strategy_allowed_for_asset,
 )
 from app.trading.strat_trader import StratTrader
 from app.utils.util import timer
@@ -75,7 +78,9 @@ class TraderDriver:
         fixed_strategy_count = 0
         configured_sma200_variants = sma200_variants or SMA200_VARIANTS
         for s in overall_stats:
-            if s == "SMA200":
+            if s == BTC_SMA200_DEFENSIVE_STRATEGY:
+                fixed_strategy_count += 1
+            elif s == "SMA200":
                 fixed_strategy_count += len(configured_sma200_variants)
             elif s == "RSI":
                 per_combo += max(1, rsi_extra)
@@ -147,6 +152,19 @@ class TraderDriver:
         """
         configured_sma200_variants = sma200_variants or SMA200_VARIANTS
         for stat in overall_stats:
+            if stat == BTC_SMA200_DEFENSIVE_STRATEGY:
+                variant = BTC_SMA200_DEFENSIVE_PARAMETERS
+                yield {
+                    "stat": stat,
+                    "tol_pct": 0.0,
+                    "buy_pct": 1.0,
+                    "sell_pct": 1.0,
+                    "bollinger_sigma": bollinger_tols[0] if bollinger_tols else 2,
+                    "sma200_entry_band_pct": float(variant["entry_band_pct"]),
+                    "sma200_exit_band_pct": float(variant["exit_band_pct"]),
+                    "sma200_min_hold_days": int(variant["min_hold_days"]),
+                }
+                continue
             if stat == "SMA200":
                 for variant in configured_sma200_variants:
                     yield {
@@ -236,6 +254,12 @@ class TraderDriver:
         Returns:
             None
         """
+        if BTC_SMA200_DEFENSIVE_STRATEGY in overall_stats and not (
+            is_crypto_strategy_allowed_for_asset(BTC_SMA200_DEFENSIVE_STRATEGY, name)
+        ):
+            raise ValueError(
+                f"{BTC_SMA200_DEFENSIVE_STRATEGY} is restricted to BTC; received {name}"
+            )
         self.name = name
         self.init_amount, self.init_coin = init_amount, cur_coin
         self.mode = mode

--- a/tests/backtesting/test_portfolio_strategy_validation.py
+++ b/tests/backtesting/test_portfolio_strategy_validation.py
@@ -1,0 +1,134 @@
+import numpy as np
+import pytest
+
+from app.backtesting.benchmark_validation import (
+    EXECUTION_FRICTION_RATE,
+    INITIAL_CAPITAL,
+)
+from app.backtesting.portfolio_strategy_validation import (
+    RotationParameters,
+    TrendParameters,
+    _feature_matrices,
+    build_equal_weight_targets,
+    build_rotation_targets,
+    build_single_asset_trend_targets,
+    simulate_portfolio,
+)
+
+
+def _features(closes, opens=None, sma200=None, vol20=None):
+    closes = np.asarray(closes, dtype=float)
+    opens = closes.copy() if opens is None else np.asarray(opens, dtype=float)
+    shape = closes.shape
+    return {
+        "closes": closes,
+        "opens": opens,
+        "sma20": closes.copy(),
+        "std20": np.ones(shape),
+        "sma200": (
+            np.full(shape, 100.0) if sma200 is None else np.asarray(sma200, dtype=float)
+        ),
+        "vol20": (
+            np.full(shape, 0.02) if vol20 is None else np.asarray(vol20, dtype=float)
+        ),
+    }
+
+
+def test_portfolio_executes_previous_close_target_at_next_open():
+    features = _features([[100.0], [110.0]], opens=[[100.0], [100.0]])
+    targets = np.asarray([[1.0], [1.0]])
+
+    result = simulate_portfolio(features, targets, 1, 2, slippage_bps=10)
+
+    quantity = INITIAL_CAPITAL * (1.0 - EXECUTION_FRICTION_RATE) / (100.0 * 1.001)
+    expected_return = (quantity * 110.0 / INITIAL_CAPITAL - 1.0) * 100.0
+    assert result["return"] == pytest.approx(expected_return)
+    assert result["transactions"] == 1
+
+
+def test_initial_execution_cost_is_included_in_drawdown():
+    features = _features([[100.0], [100.0]], opens=[[100.0], [100.0]])
+    targets = np.asarray([[1.0], [1.0]])
+
+    result = simulate_portfolio(features, targets, 1, 2, slippage_bps=10)
+
+    assert result["return"] < -2.0
+    assert result["max_drawdown"] == pytest.approx(-result["return"])
+
+
+def test_btc_gate_moves_all_assets_to_cash_after_exit_threshold():
+    closes = np.asarray([[106.0, 106.0], [110.0, 110.0], [94.0, 110.0]])
+    features = _features(closes, sma200=np.full_like(closes, 100.0))
+
+    targets = build_equal_weight_targets(features, ["BTC", "ETH"], btc_gate=True)
+
+    assert targets[1].tolist() == pytest.approx([0.5, 0.5])
+    assert targets[2].tolist() == pytest.approx([0.0, 0.0])
+
+
+def test_inverse_volatility_weights_are_frozen_between_rebalances():
+    days = 240
+    closes = np.column_stack(
+        (np.linspace(106.0, 220.0, days), np.linspace(106.0, 300.0, days))
+    )
+    vol20 = np.column_stack(
+        (np.linspace(0.01, 0.04, days), np.linspace(0.04, 0.01, days))
+    )
+    features = _features(closes, sma200=np.full_like(closes, 100.0), vol20=vol20)
+    params = RotationParameters(60, 2, 30, True, False)
+
+    targets = build_rotation_targets(features, ["BTC", "ETH"], params)
+
+    assert targets[210].sum() == pytest.approx(1.0)
+    assert targets[211].tolist() == pytest.approx(targets[210].tolist())
+
+
+def test_future_prices_do_not_change_past_rotation_targets():
+    days = 260
+    symbols = ["BTC", "ETH", "SOL"]
+
+    def data(future_multiplier):
+        result = {}
+        for asset_index, symbol in enumerate(symbols):
+            rows = []
+            for index in range(days):
+                close = 100.0 + index * (asset_index + 1) * 0.2
+                if index >= 230:
+                    close *= future_multiplier ** (asset_index + 1)
+                rows.append([close, str(index), close, close, close, 1_000.0])
+            result[symbol] = rows
+        return result
+
+    base_features = _feature_matrices(symbols, data(1.0))
+    changed_features = _feature_matrices(symbols, data(2.0))
+    params = RotationParameters(90, 2, 30, False, True)
+
+    base_targets = build_rotation_targets(base_features, symbols, params)
+    changed_targets = build_rotation_targets(changed_features, symbols, params)
+
+    assert changed_targets[:230] == pytest.approx(base_targets[:230])
+
+
+def test_bollinger_entry_waits_for_pullback_without_using_future_prices():
+    closes = np.asarray(
+        [
+            [106.0, 100.0],
+            [110.0, 100.0],
+            [104.0, 100.0],
+            [94.0, 100.0],
+        ]
+    )
+    features = _features(closes, sma200=np.full_like(closes, 100.0))
+    features["sma20"][:, 0] = 103.0
+    features["std20"][:, 0] = 2.0
+    params = TrendParameters(0.05, 0.05, 0.5)
+
+    targets = build_single_asset_trend_targets(features, ["BTC", "ETH"], "BTC", params)
+
+    assert targets[:, 0].tolist() == pytest.approx([0.0, 0.0, 0.0, 0.0])
+
+    closes[2, 0] = 106.0
+    features["closes"] = closes
+    features["sma20"][2, 0] = 106.0
+    targets = build_single_asset_trend_targets(features, ["BTC", "ETH"], "BTC", params)
+    assert targets[:, 0].tolist() == pytest.approx([0.0, 0.0, 1.0, 0.0])

--- a/tests/strategy/test_sma200_strategy.py
+++ b/tests/strategy/test_sma200_strategy.py
@@ -3,10 +3,13 @@ from datetime import datetime, timedelta
 import pytest
 
 from app.core.config import (
+    BTC_SMA200_DEFENSIVE_STRATEGY,
     BUY_SIGNAL,
+    CRYPTO_STRATEGIES,
     SELL_SIGNAL,
     SMA200_VARIANTS,
     SUPPORTED_STRATEGIES,
+    crypto_strategies_for_asset,
 )
 from app.trading.strat_trader import StratTrader
 from app.trading.strategies import STRATEGY_REGISTRY
@@ -148,3 +151,72 @@ def test_sma200_signal_executes_at_next_open_when_enabled():
         item for item in trader.trade_history if item["action"] == BUY_SIGNAL
     )
     assert buy_trade["price"] == pytest.approx(105.105)
+
+
+def test_btc_defensive_is_the_only_enabled_crypto_strategy():
+    assert CRYPTO_STRATEGIES == [BTC_SMA200_DEFENSIVE_STRATEGY]
+    assert crypto_strategies_for_asset("BTC") == [BTC_SMA200_DEFENSIVE_STRATEGY]
+    assert crypto_strategies_for_asset("ETH") == []
+    assert BTC_SMA200_DEFENSIVE_STRATEGY in SUPPORTED_STRATEGIES
+    assert STRATEGY_REGISTRY[BTC_SMA200_DEFENSIVE_STRATEGY] is not None
+
+
+def test_btc_defensive_forces_fixed_execution_configuration():
+    trader = _trader(
+        stat=BTC_SMA200_DEFENSIVE_STRATEGY,
+        sma200_entry_band_pct=0.0,
+        sma200_exit_band_pct=0.0,
+        execute_on_next_open=False,
+        slippage_bps=0.0,
+    )
+
+    assert trader.high_strategy == BTC_SMA200_DEFENSIVE_STRATEGY
+    assert trader.sma200_entry_band_pct == pytest.approx(0.05)
+    assert trader.sma200_exit_band_pct == pytest.approx(0.05)
+    assert trader.buy_pct == 1.0
+    assert trader.sell_pct == 1.0
+    assert trader.brokerage_pct == pytest.approx(0.02)
+    assert trader.execute_on_next_open is True
+    assert trader.slippage_bps == pytest.approx(10.0)
+    assert "200" in trader.moving_averages
+
+
+def test_btc_defensive_rejects_non_btc_assets_at_construction():
+    with pytest.raises(ValueError, match="restricted to BTC"):
+        _trader(name="ETH", stat=BTC_SMA200_DEFENSIVE_STRATEGY)
+
+
+def test_btc_defensive_signal_executes_on_next_daily_open():
+    trader = _trader(stat=BTC_SMA200_DEFENSIVE_STRATEGY)
+    for index in range(199):
+        _add_day(trader, index, 100, execute_strategy=False)
+
+    _add_day(trader, 199, 110)
+    assert trader.cur_coin == 0
+    assert trader.pending_order["action"] == BUY_SIGNAL
+
+    _add_day(trader, 200, 110, open_price=105)
+    expected_quantity = 10_000 * 0.98 / 105.105
+    assert trader.cur_coin == pytest.approx(expected_quantity)
+    assert trader.strat_dct[BTC_SMA200_DEFENSIVE_STRATEGY][-1][1] in {
+        BUY_SIGNAL,
+        "NO ACTION",
+    }
+
+
+def test_driver_rejects_btc_defensive_for_eth():
+    kwargs = {
+        "name": "ETH",
+        "init_amount": 10_000,
+        "cur_coin": 0.0,
+        "overall_stats": [BTC_SMA200_DEFENSIVE_STRATEGY],
+        "tol_pcts": [0.1],
+        "ma_lengths": [6, 12, 30],
+        "ema_lengths": [6, 12, 26, 30],
+        "bollinger_mas": [6, 12],
+        "bollinger_tols": [2],
+        "buy_pcts": [1.0],
+        "sell_pcts": [1.0],
+    }
+    with pytest.raises(ValueError, match="restricted to BTC"):
+        TraderDriver(**kwargs)


### PR DESCRIPTION
Registers BTC-SMA200-DEFENSIVE as the only enabled crypto strategy. Enforces BTC-only execution, fixed SMA200 hysteresis parameters, daily candles, next-open execution, 2% friction, and 10 bps slippage. Adds portfolio validation and regression tests.